### PR TITLE
[Improvement] Rename request parameters to make them accessibly by JSP expressions

### DIFF
--- a/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/site/HTMLAction.java
+++ b/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/site/HTMLAction.java
@@ -94,13 +94,13 @@ public interface HTMLAction extends Action {
   int SKIP_PAGELET = 1;
 
   /** Request parameter name for information messages */
-  String WARNINGS = "webl:warnings";
+  String WARNINGS = "weblwarnings";
 
   /** Request parameter name for information messages */
-  String INFOS = "webl:infos";
+  String INFOS = "weblinfos";
 
   /** Request parameter name for information messages */
-  String ERRORS = "webl:errors";
+  String ERRORS = "weblerrors";
 
   /**
    * This method is called by the target page and gives the action the


### PR DESCRIPTION
Rename the infos/warnings/errors request parameters like this:
- webl:infos --> weblinfos
- webl:warnings --> weblwarnings
- webl:errors --> weblwarnings

This makes them accessible in JSP expressions like ${weblinfos}.

+API
