### PR TITLE
[Bugfix] Make sure content repository does not clear complete search index

### DIFF
--- a/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/search/SearchIndex.java
+++ b/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/search/SearchIndex.java
@@ -5,6 +5,7 @@ import ch.entwine.weblounge.common.content.ResourceURI;
 import ch.entwine.weblounge.common.content.SearchQuery;
 import ch.entwine.weblounge.common.content.SearchResult;
 import ch.entwine.weblounge.common.repository.ContentRepositoryException;
+import ch.entwine.weblounge.common.site.Site;
 
 import java.io.IOException;
 import java.util.List;
@@ -84,9 +85,17 @@ public interface SearchIndex {
    */
   List<String> suggest(String dictionary, String seed, boolean onlyMorePopular,
       int count, boolean collate) throws ContentRepositoryException;
+  
+  /**
+   * Clears the search index of the given site.
+   * 
+   * @param site the site
+   * @throws IOException if clearing of the site index fails
+   */
+  void clear(Site site) throws IOException;
 
   /**
-   * Clears the search index.
+   * Clears the search indices of all sites.
    * 
    * @throws IOException
    *           if clearing the index fails

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/index/ContentRepositoryIndex.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/index/ContentRepositoryIndex.java
@@ -407,7 +407,7 @@ public class ContentRepositoryIndex {
    *           if clearing the index fails
    */
   public synchronized void clear() throws IOException {
-    searchIdx.clear();
+    searchIdx.clear(site);
   }
 
   /**


### PR DESCRIPTION
Add an additional method #clear(Site) to the SearchIndex which allows to clear
only one index. Change the method ContentRepositoryIndex#clear() to use the new
method which ensures that clearing the content repository index does not remove
the indices of all other sites.
