### PR TITLE
[Feature] Custom 404 error pages

### DIFF
--- a/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/site/Site.java
+++ b/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/site/Site.java
@@ -21,6 +21,7 @@
 package ch.entwine.weblounge.common.site;
 
 import ch.entwine.weblounge.common.Customizable;
+import ch.entwine.weblounge.common.content.ResourceURI;
 import ch.entwine.weblounge.common.content.page.PageLayout;
 import ch.entwine.weblounge.common.content.page.PageTemplate;
 import ch.entwine.weblounge.common.language.Language;
@@ -429,6 +430,17 @@ public interface Site extends Customizable, RequestListener, Serializable {
    *          the digest
    */
   void setDigestType(DigestType digest);
+
+  /**
+   * Returns the error page which should be displayed in case no other resource
+   * nor an action with the given path could be found.
+   * 
+   * @param path
+   *          the requested path
+   * @return the uri of the error page or {@code null} if there is no error
+   *         page
+   */
+  ResourceURI getErrorPage(String path);
 
   /**
    * Starts this site.

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/site/SiteImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/site/SiteImpl.java
@@ -20,6 +20,7 @@
 
 package ch.entwine.weblounge.common.impl.site;
 
+import static org.apache.commons.lang.StringUtils.isBlank;
 import static org.apache.commons.lang.StringUtils.split;
 
 import ch.entwine.weblounge.common.content.MalformedResourceURIException;
@@ -934,6 +935,9 @@ public class SiteImpl implements Site {
 
   @Override
   public ResourceURI getErrorPage(String path) {
+    if (isBlank(path))
+      throw new IllegalArgumentException("Path must not be null nor empty");
+    
     if (!this.hasOption(OPT_NAME_ERROR_PAGES))
       return null;
 

--- a/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/site/SiteImplTest.java
+++ b/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/site/SiteImplTest.java
@@ -29,9 +29,11 @@ import static org.junit.Assert.fail;
 
 import ch.entwine.weblounge.common.Times;
 import ch.entwine.weblounge.common.content.Renderer;
+import ch.entwine.weblounge.common.content.Resource;
 import ch.entwine.weblounge.common.content.image.ImageStyle;
 import ch.entwine.weblounge.common.content.page.PageTemplate;
 import ch.entwine.weblounge.common.impl.content.page.PageTemplateImpl;
+import ch.entwine.weblounge.common.impl.content.page.PageURIImpl;
 import ch.entwine.weblounge.common.impl.language.LanguageImpl;
 import ch.entwine.weblounge.common.impl.security.PasswordImpl;
 import ch.entwine.weblounge.common.impl.security.SiteAdminImpl;
@@ -190,6 +192,11 @@ public class SiteImplTest {
     site.addLocalRole(Security.EDITOR_ROLE, editorRole);
     site.addLocalRole(Security.GUEST_ROLE, guestRole);
     site.setSecurity(new URL(securityConfigPath));
+    site.setOption(SiteImpl.OPT_NAME_ERROR_PAGES, ":/bar");
+    site.setOption(SiteImpl.OPT_NAME_ERROR_PAGES, "/a:/bar");
+    site.setOption(SiteImpl.OPT_NAME_ERROR_PAGES, "/b:/bar/");
+    site.setOption(SiteImpl.OPT_NAME_ERROR_PAGES, "/c:");
+    site.setOption(SiteImpl.OPT_NAME_ERROR_PAGES, "/d:bar");
   }
 
   /**
@@ -538,12 +545,23 @@ public class SiteImplTest {
   
   /**
    * Test method for
-   * {@link ch.entwine.weblounge.common.impl.site.SiteImpl#getSecurity()}
-   * .
+   * {@link ch.entwine.weblounge.common.impl.site.SiteImpl#getSecurity()} .
    */
   @Test
   public void testGetSecurity() {
     assertEquals(securityConfigPath, site.getSecurity().toExternalForm());
+  }
+
+  /**
+   * Test method for {@link SiteImpl#getErrorPage(String)}
+   */
+  @Test
+  public void testGetErrorPage() {
+    PageURIImpl errorpage = new PageURIImpl(site, "/bar", Resource.LIVE);
+    assertEquals(errorpage, site.getErrorPage("/a"));
+    assertEquals(errorpage, site.getErrorPage("/b"));
+    assertEquals(null, site.getErrorPage("/c"));
+    assertEquals(errorpage, site.getErrorPage("/d"));
   }
 
 }

--- a/modules/weblounge-common/src/test/resources/site.xml
+++ b/modules/weblounge-common/src/test/resources/site.xml
@@ -51,5 +51,13 @@
       <name>media.url</name>
       <value><![CDATA[http://media.swissunihockey.ch/dev]]></value>
     </option>
+    <option>
+      <name>weblounge.errorpages</name>
+      <value><![CDATA[/a:/bar]]></value>
+      <value><![CDATA[/b:/bar/]]></value>
+      <value><![CDATA[/c:]]></value>
+      <value><![CDATA[/d:bar]]></value>
+      <value><![CDATA[:/bar]]></value>
+    </option>
   </options>
 </site>

--- a/modules/weblounge-dispatcher/pom.xml
+++ b/modules/weblounge-dispatcher/pom.xml
@@ -211,6 +211,7 @@
               OSGI-INF/feed-requesthandler.xml,
               OSGI-INF/file-requesthandler.xml,
               OSGI-INF/image-requesthandler.xml,
+              OSGI-INF/not-found-requesthandler.xml,
               OSGI-INF/page-requesthandler.xml,
               OSGI-INF/preview-requesthandler.xml,
               OSGI-INF/robots-requesthandler.xml,

--- a/modules/weblounge-dispatcher/src/main/java/ch/entwine/weblounge/dispatcher/impl/handler/NotFoundRequestHandlerImpl.java
+++ b/modules/weblounge-dispatcher/src/main/java/ch/entwine/weblounge/dispatcher/impl/handler/NotFoundRequestHandlerImpl.java
@@ -1,0 +1,128 @@
+/*
+ *  Weblounge: Web Content Management System
+ *  Copyright (c) 2003 - 2011 The Weblounge Team
+ *  http://entwinemedia.com/weblounge
+ *
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public License
+ *  as published by the Free Software Foundation; either version 2
+ *  of the License, or (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with this program; if not, write to the Free Software Foundation
+ *  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+
+package ch.entwine.weblounge.dispatcher.impl.handler;
+
+import ch.entwine.weblounge.common.content.ResourceURI;
+import ch.entwine.weblounge.common.content.page.Page;
+import ch.entwine.weblounge.common.repository.ContentRepository;
+import ch.entwine.weblounge.common.repository.ContentRepositoryException;
+import ch.entwine.weblounge.common.request.WebloungeRequest;
+import ch.entwine.weblounge.common.request.WebloungeResponse;
+import ch.entwine.weblounge.common.site.Site;
+import ch.entwine.weblounge.common.url.WebUrl;
+import ch.entwine.weblounge.dispatcher.RequestHandler;
+import ch.entwine.weblounge.dispatcher.impl.DispatchUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * This request handler tries to handle requests which could not be served by
+ * any other request handler.
+ */
+public class NotFoundRequestHandlerImpl implements RequestHandler {
+
+  /** The logging facility */
+  private static final Logger logger = LoggerFactory.getLogger(NotFoundRequestHandlerImpl.class);
+
+  @Override
+  public boolean service(WebloungeRequest request, WebloungeResponse response) {
+
+    logger.debug("Not Found Request Handler starts handling request");
+
+    Site site = request.getSite();
+    WebUrl url = request.getRequestedUrl();
+    String path = request.getRequestURI();
+
+    ResourceURI pageUri = site.getErrorPage(path);
+
+    if (pageUri == null) {
+      logger.debug("Site {} has no 404 error page for path '{}' configured", site, path);
+      return false;
+    }
+
+    // Check the request method. This handler only supports GET
+    String requestMethod = request.getMethod().toUpperCase();
+    if ("OPTIONS".equals(requestMethod)) {
+      String verbs = "OPTIONS,GET";
+      logger.trace("Answering options request to {} with {}", url, verbs);
+      response.setHeader("Allow", verbs);
+      response.setContentLength(0);
+      return true;
+    } else if (!"GET".equals(requestMethod)) {
+      logger.debug("Feed request handler does not support {} requests", url, requestMethod);
+      DispatchUtils.sendError(HttpServletResponse.SC_METHOD_NOT_ALLOWED, request, response);
+      return true;
+    }
+
+    // Check if we have a working content repository
+    ContentRepository contentRepository = site.getContentRepository();
+    if (contentRepository == null) {
+      logger.warn("Content repository not available to read page '{}'", pageUri);
+      DispatchUtils.sendInternalError(request, response);
+      return true;
+    }
+
+    // Read the page from the content repository
+    Page page;
+    try {
+      page = contentRepository.get(pageUri);
+    } catch (ContentRepositoryException e) {
+      logger.error("Error getting page '{}' from content repository", pageUri);
+      DispatchUtils.sendInternalError(request, response);
+      return true;
+    }
+
+    if (page == null) {
+      logger.warn("The 404 error page '{}' could not be found in the content repository");
+      DispatchUtils.sendError(HttpServletResponse.SC_NOT_FOUND, request, response);
+      return true;
+    }
+
+    logger.debug("Found 404 error page '{}' for requested path '{}", page, path);
+
+    // Let the page request handler do the remaining work
+    request.setAttribute(WebloungeRequest.PAGE, page);
+    PageRequestHandlerImpl.getInstance().service(request, response);
+    request.removeAttribute(WebloungeRequest.PAGE);
+
+    return true;
+  }
+
+  @Override
+  public int getPriority() {
+    // Make sure, this request handler is last in the chain
+    return -100;
+  }
+
+  @Override
+  public String getName() {
+    return toString();
+  }
+
+  @Override
+  public String toString() {
+    return "404 Not Found Request Handler";
+  }
+
+}

--- a/modules/weblounge-dispatcher/src/main/java/ch/entwine/weblounge/dispatcher/impl/handler/PageRequestHandlerImpl.java
+++ b/modules/weblounge-dispatcher/src/main/java/ch/entwine/weblounge/dispatcher/impl/handler/PageRequestHandlerImpl.java
@@ -221,14 +221,14 @@ public final class PageRequestHandlerImpl implements PageRequestHandler {
 
           // Did we find a matching uri?
           if (pageURI == null) {
-            DispatchUtils.sendNotFound(request, response);
-            return true;
+            logger.debug("Page '{}' not found", requestURI);
+            return false;
           }
 
           page = (Page) contentRepository.get(pageURI);
           if (page == null) {
-            DispatchUtils.sendNotFound(request, response);
-            return true;
+            logger.debug("Page '{}' not found", pageURI);
+            return false;
           }
         } catch (ContentRepositoryException e) {
           logger.error("Unable to load page {} from {}: {}", new Object[] {

--- a/modules/weblounge-dispatcher/src/main/resources/OSGI-INF/not-found-requesthandler.xml
+++ b/modules/weblounge-dispatcher/src/main/resources/OSGI-INF/not-found-requesthandler.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+  immediate="true"
+  name="Weblounge Not Found Request Handler">
+
+  <implementation class="ch.entwine.weblounge.dispatcher.impl.handler.NotFoundRequestHandlerImpl" />
+  <property name="service.description" value="Weblounge Not Found Request Handler" />
+  <service>
+    <provide interface="ch.entwine.weblounge.dispatcher.RequestHandler" />
+  </service>
+
+</scr:component>


### PR DESCRIPTION
Add a new request handler (NotFoundRequestHandler) which usually should be at
the very end of the request handler chain. It checks if there is an error page
configured for the requested path and returns it if present.
