### PR TITLE
[Feature] Add information about origin & original identifier to resource

### DIFF
--- a/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/Resource.java
+++ b/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/Resource.java
@@ -121,6 +121,34 @@ public interface Resource<T extends ResourceContent> extends Localizable, Creata
   long getVersion();
 
   /**
+   * Sets the origin of the resource.
+   * 
+   * @param origin the origin
+   */
+  void setOrigin(String origin);
+
+  /**
+   * Returns the origin of the resource.
+   * 
+   * @return the origin
+   */
+  String getOrigin();
+  
+  /**
+   * Sets the original identifier (in the origin system) of the resource
+   * 
+   * @param identifier the original identifier
+   */
+  void setOriginalIdentifier(String identifier);
+  
+  /**
+   * Returns the original identifier (in the origin system) of the resource.
+   * 
+   * @return the original identifier
+   */
+  String getOriginalIdentifier();
+
+  /**
    * Makes this a promoted resource. Specifying a collection of promoted pages
    * throughout a site will allow for building a sitemap or a list of points of
    * entrance.

--- a/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/ResourceContent.java
+++ b/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/ResourceContent.java
@@ -46,21 +46,6 @@ public interface ResourceContent extends Creatable {
   String getFilename();
 
   /**
-   * Sets the identifier that was used when the content was initially acquired.
-   * 
-   * @param source
-   *          the source
-   */
-  void setSource(String source);
-
-  /**
-   * Returns the resource content's original identifier.
-   * 
-   * @return the source
-   */
-  String getSource();
-
-  /**
    * Sets the resource content's external location.
    * 
    * @param location

--- a/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/SearchQuery.java
+++ b/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/SearchQuery.java
@@ -171,20 +171,36 @@ public interface SearchQuery {
   boolean isStationary();
 
   /**
-   * Return the resources with the given source.
+   * Return the resources with the given origin.
    * 
-   * @param source
-   *          the source to look up
+   * @param origin
+   *          the origin to look up
    * @return the query extended by this criterion
    */
-  SearchQuery withSource(String source);
+  SearchQuery withOrigin(String origin);
+  
+  /**
+   * Return the resources with the given original identifier.
+   * 
+   * @param originalIdentifier
+   *          the original identifier to look up
+   * @return the query extended by this criterion
+   */
+  SearchQuery withOriginalIdentifier(String originalIdentifier);
 
   /**
-   * Returns the source or <code>null</code> if no source was specified.
+   * Returns the origin or <code>null</code> if no origin was specified.
    * 
-   * @return the source
+   * @return the origin
    */
-  String getSource();
+  String getOrigin();
+
+  /**
+   * Returns the original identifier or <code>null</code> if no original identifier was specified.
+   * 
+   * @return the original identifier
+   */
+  String getOriginalIdentifier();
 
   /**
    * Return the resources which have an external representation at the given

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/AbstractResourceReaderImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/AbstractResourceReaderImpl.java
@@ -345,6 +345,16 @@ public abstract class AbstractResourceReaderImpl<S extends ResourceContent, T ex
       if ("promote".equals(raw)) {
         resource.setPromoted("true".equals(characters.toString()));
       }
+      
+      // Origin
+      if ("origin".equals(raw)) {
+        resource.setOrigin(characters.toString());
+      }
+      
+      // Original identifier
+      if ("original-identifier".equals(raw)) {
+        resource.setOriginalIdentifier(characters.toString());
+      }
 
       // Type
       else if ("type".equals(raw)) {

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/ResourceContentImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/ResourceContentImpl.java
@@ -37,9 +37,6 @@ public class ResourceContentImpl implements ResourceContent {
   /** The content's name */
   protected String filename = null;
 
-  /** The content's source */
-  protected String source = null;
-
   /** The content's external location */
   protected URL externalLocation = null;
 
@@ -120,24 +117,6 @@ public class ResourceContentImpl implements ResourceContent {
    */
   public String getFilename() {
     return filename;
-  }
-
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.ResourceContent#setSource(java.lang.String)
-   */
-  public void setSource(String source) {
-    this.source = source;
-  }
-
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.ResourceContent#getSource()
-   */
-  public String getSource() {
-    return source;
   }
 
   /**
@@ -345,8 +324,6 @@ public class ResourceContentImpl implements ResourceContent {
     buf.append(creationCtx.toXml());
     if (filename != null)
       buf.append("<filename><![CDATA[").append(filename).append("]]></filename>");
-    if (source != null)
-      buf.append("<source>").append(source).append("</source>");
     if (externalLocation != null)
       buf.append("<external>").append(externalLocation).append("</external>");
     if (!StringUtils.isBlank(author))

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/ResourceContentReaderImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/ResourceContentReaderImpl.java
@@ -172,12 +172,6 @@ public abstract class ResourceContentReaderImpl<T extends ResourceContent> exten
       logger.trace("Content's filename is '{}'", content.getFilename());
     }
 
-    // source
-    else if ("source".equals(raw)) {
-      content.setSource(getCharacters());
-      logger.trace("Content's source is '{}'", content.getSource());
-    }
-
     // external
     else if ("external".equals(raw)) {
       try {
@@ -185,7 +179,7 @@ public abstract class ResourceContentReaderImpl<T extends ResourceContent> exten
       } catch (MalformedURLException e) {
         throw new SAXException(e);
       }
-      logger.trace("Content's external location is '{}'", content.getSource());
+      logger.trace("Content's external location is '{}'", content.getExternalLocation());
     }
 
     // author

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/ResourceImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/ResourceImpl.java
@@ -66,6 +66,12 @@ public abstract class ResourceImpl<T extends ResourceContent> extends Localizabl
   /** The uri */
   protected ResourceURI uri = null;
 
+  /** The resource origin */
+  protected String origin = null;
+
+  /** The resource origin identifier */
+  protected String originIdentifier = null;
+
   /** Resource type */
   protected String type = null;
 
@@ -226,6 +232,46 @@ public abstract class ResourceImpl<T extends ResourceContent> extends Localizabl
    */
   public void setVersion(long version) {
     uri.setVersion(version);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOrigin(java.lang.String)
+   */
+  @Override
+  public void setOrigin(String origin) {
+    this.origin = origin;
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOrigin()
+   */
+  @Override
+  public String getOrigin() {
+    return this.origin;
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOriginalIdentifier(java.lang.String)
+   */
+  @Override
+  public void setOriginalIdentifier(String identifier) {
+    this.originIdentifier = identifier;
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOriginalIdentifier()
+   */
+  @Override
+  public String getOriginalIdentifier() {
+    return this.originIdentifier;
   }
 
   /**
@@ -1037,6 +1083,14 @@ public abstract class ResourceImpl<T extends ResourceContent> extends Localizabl
     b.append("<index>");
     b.append(Boolean.toString(isIndexed));
     b.append("</index>");
+
+    b.append("<origin>");
+    b.append(origin);
+    b.append("</origin>");
+
+    b.append("<original-identifier>");
+    b.append(originIdentifier);
+    b.append("</original-identifier>");
 
     // Metadata
     b.append("<metadata>");

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/SearchQueryImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/SearchQueryImpl.java
@@ -107,8 +107,11 @@ public class SearchQueryImpl implements SearchQuery {
   /** The external location */
   protected URL externalLocation = null;
 
-  /** The source */
-  protected String source = null;
+  /** The origin */
+  protected String origin = null;
+
+  /** The original identifier */
+  protected String originalIdentifier = null;
 
   /** The properties */
   protected Map<String, String> properties = new HashMap<String, String>();
@@ -1457,20 +1460,39 @@ public class SearchQueryImpl implements SearchQuery {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.SearchQuery#withSource(java.lang.String)
+   * @see ch.entwine.weblounge.common.content.SearchQuery#withOrigin(String)
    */
-  public SearchQuery withSource(String source) {
-    this.source = source;
+  public SearchQuery withOrigin(String origin) {
+    this.origin = origin;
     return this;
   }
 
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.SearchQuery#getSource()
+   * @see ch.entwine.weblounge.common.content.SearchQuery#getOrigin()
    */
-  public String getSource() {
-    return source;
+  public String getOrigin() {
+    return origin;
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.SearchQuery#withOriginalIdentifier(String)
+   */
+  public SearchQuery withOriginalIdentifier(String originalIdentifier) {
+    this.originalIdentifier = originalIdentifier;
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.SearchQuery#getOriginalIdentifier()
+   */
+  public String getOriginalIdentifier() {
+    return originalIdentifier;
   }
 
   /**

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/file/LazyFileResourceImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/file/LazyFileResourceImpl.java
@@ -452,6 +452,30 @@ public class LazyFileResourceImpl implements FileResource {
   /**
    * {@inheritDoc}
    * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOrigin()
+   */
+  @Override
+  public String getOrigin() {
+    if (!isHeaderLoaded)
+      loadFileHeader();
+    return file.getOrigin();
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOriginalIdentifier()
+   */
+  @Override
+  public String getOriginalIdentifier() {
+    if (!isHeaderLoaded)
+      loadFileHeader();
+    return file.getOriginalIdentifier();
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
    * @see ch.entwine.weblounge.common.content.file.Page#hasSubject(java.lang.String)
    */
   public boolean hasSubject(String subject) {
@@ -546,6 +570,30 @@ public class LazyFileResourceImpl implements FileResource {
    */
   public void setIdentifier(String identifier) {
     uri.setIdentifier(identifier);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOrigin(java.lang.String)
+   */
+  @Override
+  public void setOrigin(String origin) {
+    if (!isHeaderLoaded)
+      loadFileHeader();
+    file.setOrigin(origin);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOriginalIdentifier(java.lang.String)
+   */
+  @Override
+  public void setOriginalIdentifier(String identifier) {
+    if (!isHeaderLoaded)
+      loadFileHeader();
+    file.setOriginalIdentifier(identifier);
   }
 
   /**

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/image/LazyImageResourceImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/image/LazyImageResourceImpl.java
@@ -447,6 +447,30 @@ public class LazyImageResourceImpl implements ImageResource {
   /**
    * {@inheritDoc}
    * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOrigin()
+   */
+  @Override
+  public String getOrigin() {
+    if (!isHeaderLoaded)
+      loadImageHeader();
+    return image.getOrigin();
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOriginalIdentifier()
+   */
+  @Override
+  public String getOriginalIdentifier() {
+    if (!isHeaderLoaded)
+      loadImageHeader();
+    return image.getOriginalIdentifier();
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
    * @see ch.entwine.weblounge.common.content.image.Page#hasSubject(java.lang.String)
    */
   public boolean hasSubject(String subject) {
@@ -541,6 +565,30 @@ public class LazyImageResourceImpl implements ImageResource {
    */
   public void setIdentifier(String identifier) {
     uri.setIdentifier(identifier);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOrigin(java.lang.String)
+   */
+  @Override
+  public void setOrigin(String origin) {
+    if (!isHeaderLoaded)
+      loadImageHeader();
+    image.setOrigin(origin);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOriginalIdentifier(java.lang.String)
+   */
+  @Override
+  public void setOriginalIdentifier(String identifier) {
+    if (!isHeaderLoaded)
+      loadImageHeader();
+    image.setOriginalIdentifier(identifier);
   }
 
   /**

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/movie/LazyMovieResourceImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/movie/LazyMovieResourceImpl.java
@@ -448,6 +448,30 @@ public class LazyMovieResourceImpl implements MovieResource {
   /**
    * {@inheritDoc}
    * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOrigin()
+   */
+  @Override
+  public String getOrigin() {
+    if (!isHeaderLoaded)
+      loadAudioVisualHeader();
+    return audioVisual.getOrigin();
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOriginalIdentifier()
+   */
+  @Override
+  public String getOriginalIdentifier() {
+    if (!isHeaderLoaded)
+      loadAudioVisualHeader();
+    return audioVisual.getOriginalIdentifier();
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
    * @see ch.entwine.weblounge.common.content.Resource#hasSubject(java.lang.String)
    */
   public boolean hasSubject(String subject) {
@@ -542,6 +566,30 @@ public class LazyMovieResourceImpl implements MovieResource {
    */
   public void setIdentifier(String identifier) {
     uri.setIdentifier(identifier);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOrigin(java.lang.String)
+   */
+  @Override
+  public void setOrigin(String origin) {
+    if (!isHeaderLoaded)
+      loadAudioVisualHeader();
+    audioVisual.setOrigin(origin);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOriginalIdentifier(java.lang.String)
+   */
+  @Override
+  public void setOriginalIdentifier(String identifier) {
+    if (!isHeaderLoaded)
+      loadAudioVisualHeader();
+    audioVisual.setOriginalIdentifier(identifier);
   }
 
   /**

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/LazyPageImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/LazyPageImpl.java
@@ -613,6 +613,30 @@ public class LazyPageImpl implements Page {
   /**
    * {@inheritDoc}
    * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOrigin()
+   */
+  @Override
+  public String getOrigin() {
+    if (!isHeaderLoaded)
+      loadPageHeader();
+    return page.getOrigin();
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOriginalIdentifier()
+   */
+  @Override
+  public String getOriginalIdentifier() {
+    if (!isHeaderLoaded)
+      loadPageHeader();
+    return page.getOriginalIdentifier();
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
    * @see ch.entwine.weblounge.common.content.page.Page#hasSubject(java.lang.String)
    */
   public boolean hasSubject(String subject) {
@@ -753,6 +777,30 @@ public class LazyPageImpl implements Page {
    */
   public void setIdentifier(String identifier) {
     uri.setIdentifier(identifier);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOrigin(java.lang.String)
+   */
+  @Override
+  public void setOrigin(String origin) {
+    if (!isHeaderLoaded)
+      loadPageHeader();
+    page.setOrigin(origin);
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOriginalIdentifier(java.lang.String)
+   */
+  @Override
+  public void setOriginalIdentifier(String identifier) {
+    if (!isHeaderLoaded)
+      loadPageHeader();
+    page.setOriginalIdentifier(identifier);
   }
 
   /**

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/MockPageImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/MockPageImpl.java
@@ -168,6 +168,46 @@ public class MockPageImpl implements Page {
   /**
    * {@inheritDoc}
    * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOrigin(java.lang.String)
+   */
+  @Override
+  public void setOrigin(String origin) {
+    throw new UnsupportedOperationException("Not implemented in mock page");
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOrigin()
+   */
+  @Override
+  public String getOrigin() {
+    return new String("Not implemented in mock page");
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#setOriginalIdentifier(java.lang.String)
+   */
+  @Override
+  public void setOriginalIdentifier(String identifier) {
+    throw new UnsupportedOperationException("Not implemented in mock page");
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.Resource#getOriginalIdentifier()
+   */
+  @Override
+  public String getOriginalIdentifier() {
+    return new String("Not implemented in mock page");
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
    * @see ch.entwine.weblounge.common.content.Resource#setPromoted(boolean)
    */
   public void setPromoted(boolean promoted) {

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/PageReader.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/PageReader.java
@@ -407,6 +407,16 @@ public class PageReader extends WebloungeContentReader implements ResourceReader
       else if ("promote".equals(raw)) {
         page.setPromoted("true".equals(getCharacters()));
       }
+      
+      // Origin
+      if ("origin".equals(raw)) {
+        page.setOrigin(characters.toString());
+      }
+      
+      // Original identifier
+      if ("original-identifier".equals(raw)) {
+        page.setOriginalIdentifier(characters.toString());
+      }
 
       // Type
       else if ("type".equals(raw)) {

--- a/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/SearchQueryImplTest.java
+++ b/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/SearchQueryImplTest.java
@@ -167,6 +167,26 @@ public class SearchQueryImplTest {
     query.withStationary();
     assertTrue(query.isStationary());
   }
+  
+  /**
+   * Test method for {@link SearchQueryImpl#withOrigin(String)
+   */
+  @Test
+  public void testWithOrigin() throws Exception {
+    String origin = "test-origin";
+    query.withOrigin(origin);
+    assertEquals(origin, query.getOrigin());
+  }
+  
+  /**
+   * Test method for {@link SearchQueryImpl#withOrigin(String)
+   */
+  @Test
+  public void testWithOriginalIdentifier() throws Exception {
+    String originId = "test-origin-id";
+    query.withOriginalIdentifier(originId);
+    assertEquals(originId, query.getOriginalIdentifier());
+  }
 
   /**
    * Test method for

--- a/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/file/FileContentImplTest.java
+++ b/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/file/FileContentImplTest.java
@@ -81,7 +81,6 @@ public class FileContentImplTest {
   public void setUp() throws Exception {
     content = new FileContentImpl(filename, german, mimetype, size);
     content.setMimetype(mimetype);
-    content.setSource(source);
     content.setExternalLocation(new URL(externalLocation));
     content.setAuthor(author);
     ((FileContentImpl) content).setCreated(creationDate, amelie);
@@ -115,16 +114,6 @@ public class FileContentImplTest {
   @Test
   public void testGetFilename() {
     assertEquals(filename, content.getFilename());
-  }
-
-  /**
-   * Test method for
-   * {@link ch.entwine.weblounge.common.impl.content.file.FileContentImpl#getSource()}
-   * .
-   */
-  @Test
-  public void testGetSource() {
-    assertEquals(source, content.getSource());
   }
 
   /**

--- a/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/image/ImageContentImplTest.java
+++ b/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/image/ImageContentImplTest.java
@@ -62,9 +62,6 @@ public class ImageContentImplTest {
   /** The creation date */
   protected User amelie = new UserImpl("amelie", "testland", "Amélie Poulard");
 
-  /** The source file */
-  protected String source = "http://entwinemedia.com/imagexyz.ogg";
-
   /** The image width */
   protected int width = 2188;
 
@@ -106,7 +103,6 @@ public class ImageContentImplTest {
     image = new ImageContentImpl(filename, german, mimetype, width, height, size);
     image.setAuthor(photographer);
     image.setDateTaken(dateTaken);
-    image.setSource(source);
     image.setLocation(location);
     image.setGpsPosition(gpsLat, gpsLong);
     image.setFilmspeed(filmspeed);
@@ -134,16 +130,6 @@ public class ImageContentImplTest {
   @Test
   public void testGetMimetype() {
     assertEquals(mimetype, image.getMimetype());
-  }
-
-  /**
-   * Test method for
-   * {@link ch.entwine.weblounge.common.impl.content.image.ImageContentImpl#getSource()}
-   * .
-   */
-  @Test
-  public void testGetSource() {
-    assertEquals(source, image.getSource());
   }
 
   /**

--- a/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/movie/MovieContentImplTest.java
+++ b/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/movie/MovieContentImplTest.java
@@ -29,9 +29,6 @@ public class MovieContentImplTest {
   /** The filename */
   protected String filename = "movie.mov";
 
-  /** The source file */
-  protected String source = "http://entwinemedia.com/moviexyz.ogg";
-
   /** The English language */
   protected Language english = LanguageUtils.getLanguage("en");
 
@@ -101,7 +98,6 @@ public class MovieContentImplTest {
     videoStream.setScanType(scanType);
 
     movie = new MovieContentImpl(filename, english, mimetype, size, duration);
-    movie.setSource(source);
     movie.addStream(audioStream);
     movie.addStream(videoStream);
     ((MovieContentImpl) movie).setCreated(creationDate, amelie);
@@ -125,16 +121,6 @@ public class MovieContentImplTest {
   @Test
   public void testGetMimetype() {
     assertEquals(mimetype, movie.getMimetype());
-  }
-
-  /**
-   * Test method for
-   * {@link ch.entwine.weblounge.common.impl.content.movie.MovieContentImpl#getSource()}
-   * .
-   */
-  @Test
-  public void testGetSource() {
-    assertEquals(source, movie.getSource());
   }
 
   /**

--- a/modules/weblounge-common/src/test/resources/file.xml
+++ b/modules/weblounge-common/src/test/resources/file.xml
@@ -3,6 +3,8 @@
   <head>
     <promote>true</promote>
     <index>true</index>
+    <origin>newspaper</origin>
+    <original-identifier>123-45-678</original-identifier>
     <metadata>
       <title language="de"><![CDATA[Seitentitel]]></title>
       <title language="fr"><![CDATA[Il titre de la page]]></title>

--- a/modules/weblounge-common/src/test/resources/file2.xml
+++ b/modules/weblounge-common/src/test/resources/file2.xml
@@ -3,6 +3,8 @@
   <head>
     <promote>true</promote>
     <index>true</index>
+    <origin>newspaper</origin>
+    <original-identifier>123-45-678</original-identifier>
     <metadata>
       <title language="de"><![CDATA[Seitentitel]]></title>
       <title language="fr"><![CDATA[Il titre de la page]]></title>

--- a/modules/weblounge-common/src/test/resources/filecontent.xml
+++ b/modules/weblounge-common/src/test/resources/filecontent.xml
@@ -4,7 +4,6 @@
     <date>2009-01-07T20:05:41Z</date>
   </created>
   <filename><![CDATA[document.pdf]]></filename>
-  <source>http://entwinmedia.com/filexyz.ogg</source>
   <external>http://www.youtube.com/watch?v=UF8uR6Z6KLc</external>
   <author><![CDATA[Hans Muster]]></author>
   <mimetype>application/pdf</mimetype>

--- a/modules/weblounge-common/src/test/resources/imagecontent.xml
+++ b/modules/weblounge-common/src/test/resources/imagecontent.xml
@@ -4,7 +4,6 @@
     <date>2009-01-07T20:05:41Z</date>
   </created>
   <filename><![CDATA[Stadt.jpg]]></filename>
-  <source>http://entwinemedia.com/imagexyz.ogg</source>
   <author><![CDATA[Hans Muster]]></author>
   <mimetype>image/jpeg</mimetype>
   <size>1408338</size>

--- a/modules/weblounge-common/src/test/resources/movie.xml
+++ b/modules/weblounge-common/src/test/resources/movie.xml
@@ -3,6 +3,8 @@
   <head>
     <promote>true</promote>
     <index>true</index>
+    <origin>newspaper</origin>
+    <original-identifier>123-45-678</original-identifier>
     <metadata>
       <title language="de"><![CDATA[Film]]></title>
       <title language="fr"><![CDATA[Video]]></title>

--- a/modules/weblounge-common/src/test/resources/moviecontent.xml
+++ b/modules/weblounge-common/src/test/resources/moviecontent.xml
@@ -4,7 +4,6 @@
     <date>2009-01-07T20:05:41Z</date>
   </created>
   <filename><![CDATA[movie.mov]]></filename>
-  <source>http://entwinemedia.com/moviexyz.ogg</source>
   <mimetype>video/quicktime</mimetype>
   <size>745569</size>
   <duration>1004400000</duration>

--- a/modules/weblounge-common/src/test/resources/page.xml
+++ b/modules/weblounge-common/src/test/resources/page.xml
@@ -6,6 +6,8 @@
     <layout>news</layout>
     <promote>true</promote>
     <index>true</index>
+    <origin>newspaper</origin>
+    <original-identifier>123-45-678</original-identifier>
     <metadata>
       <title language="de"><![CDATA[Seitentitel]]></title>
       <title language="fr"><![CDATA[Il titre de la page]]></title>

--- a/modules/weblounge-common/src/test/resources/page2.xml
+++ b/modules/weblounge-common/src/test/resources/page2.xml
@@ -5,6 +5,8 @@
     <layout>news</layout>
     <promote>true</promote>
     <index>true</index>
+    <origin>newspaper</origin>
+    <original-identifier>123-45-678</original-identifier>
     <metadata>
       <title language="de"><![CDATA[Seitentitel]]></title>
       <title language="fr"><![CDATA[Il titre de la page]]></title>

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/IndexSchema.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/IndexSchema.java
@@ -43,6 +43,12 @@ public interface IndexSchema {
   /** Version field name */
   String VERSION = "version";
 
+  /** Resource origin field name */
+  String ORIGIN = "origin";
+  
+  /** Resource original identifier field name */
+  String ORIGINAL_IDENTIFIER = "original_identifier";
+
   /** Alternate version field name */
   String ALTERNATE_VERSION = "alternate_version";
 
@@ -162,9 +168,6 @@ public interface IndexSchema {
 
   /** Pagelet type field name (position within composer) */
   String PAGELET_TYPE_COMPOSER_POSITION = "pagelet_type_composer_{0}_position_{1}";
-
-  /** Resource content source field name */
-  String CONTENT_SOURCE = "content_source";
 
   /** Resource content external representation field name */
   String CONTENT_EXTERNAL_REPRESENTATION = "content_external_representation";

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/ResourceInputDocument.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/ResourceInputDocument.java
@@ -27,7 +27,6 @@ import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_FILENAME;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_FILENAME_LOCALIZED;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_MIMETYPE;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_MIMETYPE_LOCALIZED;
-import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_SOURCE;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_XML;
 import static ch.entwine.weblounge.search.impl.IndexSchema.COVERAGE;
 import static ch.entwine.weblounge.search.impl.IndexSchema.COVERAGE_LOCALIZED;
@@ -42,6 +41,8 @@ import static ch.entwine.weblounge.search.impl.IndexSchema.LOCKED_BY_NAME;
 import static ch.entwine.weblounge.search.impl.IndexSchema.MODIFIED;
 import static ch.entwine.weblounge.search.impl.IndexSchema.MODIFIED_BY;
 import static ch.entwine.weblounge.search.impl.IndexSchema.MODIFIED_BY_NAME;
+import static ch.entwine.weblounge.search.impl.IndexSchema.ORIGIN;
+import static ch.entwine.weblounge.search.impl.IndexSchema.ORIGINAL_IDENTIFIER;
 import static ch.entwine.weblounge.search.impl.IndexSchema.OWNED_BY;
 import static ch.entwine.weblounge.search.impl.IndexSchema.OWNED_BY_NAME;
 import static ch.entwine.weblounge.search.impl.IndexSchema.PATH;
@@ -118,6 +119,9 @@ public class ResourceInputDocument extends ResourceMetadataCollection {
       }
     }
 
+    addField(ORIGIN, resource.getOrigin(), true, false);
+    addField(ORIGINAL_IDENTIFIER, resource.getOriginalIdentifier(), true, false);
+
     // Resource-level
     for (String subject : resource.getSubjects())
       addField(SUBJECT, subject, true, false);
@@ -172,7 +176,6 @@ public class ResourceInputDocument extends ResourceMetadataCollection {
       addField(getLocalizedFieldName(CONTENT_XML, l), content.toXml(), false, false);
       addField(getLocalizedFieldName(CONTENT_CREATED, l), IndexUtils.serializeDate(content.getCreationDate()), false, false);
       addField(getLocalizedFieldName(CONTENT_CREATED_BY, l), IndexUtils.serializeUserId(content.getCreator()), false, false);
-      addField(CONTENT_SOURCE, content.getSource(), true, false);
       addField(CONTENT_EXTERNAL_REPRESENTATION, content.getExternalLocation(), true, false);
       addField(CONTENT_FILENAME, content.getFilename(), true, true);
       addField(getLocalizedFieldName(CONTENT_FILENAME_LOCALIZED, l), content.getFilename(), true, true);

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/elasticsearch/ElasticSearchSearchQuery.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/elasticsearch/ElasticSearchSearchQuery.java
@@ -24,7 +24,8 @@ import static ch.entwine.weblounge.search.impl.IndexSchema.ALTERNATE_VERSION;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_EXTERNAL_REPRESENTATION;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_FILENAME;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_MIMETYPE;
-import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_SOURCE;
+import static ch.entwine.weblounge.search.impl.IndexSchema.ORIGIN;
+import static ch.entwine.weblounge.search.impl.IndexSchema.ORIGINAL_IDENTIFIER;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CREATED;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CREATED_BY;
 import static ch.entwine.weblounge.search.impl.IndexSchema.FULLTEXT;
@@ -347,9 +348,14 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
       and(CONTENT_FILENAME, query.getFilename(), true);
     }
 
-    // Content source
-    if (query.getSource() != null) {
-      and(CONTENT_SOURCE, query.getSource(), true);
+    // Resource origin
+    if (query.getOrigin() != null) {
+      and(ORIGIN, query.getOrigin(), true);
+    }
+
+    // Resource original identifier
+    if (query.getOriginalIdentifier() != null) {
+      and(ORIGINAL_IDENTIFIER, query.getOriginalIdentifier(), true);
     }
 
     // Content external location


### PR DESCRIPTION
This commit introduces to new fields on a resource object: the origin (name)
and the original identifier. With the two new properties, a resource, which
originates from an other system, can now be tracked by it's origin and the
original identifier.

As a part of this change, the previously known property 'source' of the
ResourceContent interface got removed. This is a breaking API change!
