### PR TITLE
[Improvement] Rename resource field 'type' to 'flavor'

### DIFF
--- a/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/Resource.java
+++ b/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/Resource.java
@@ -60,12 +60,12 @@ public interface Resource<T extends ResourceContent> extends Localizable, Creata
   ResourceURI getURI();
 
   /**
-   * Sets the resource type.
+   * Sets the resource flavor.
    * 
-   * @param type
-   *          the resource type
+   * @param flavor
+   *          the resource flavor
    */
-  void setType(String type);
+  void setFlavor(String flavor);
 
   /**
    * Returns the resource type, which is used to include this resource into news
@@ -73,7 +73,7 @@ public interface Resource<T extends ResourceContent> extends Localizable, Creata
    * 
    * @return the resource type
    */
-  String getType();
+  String getFlavor();
 
   /**
    * Sets the resource identifier.

--- a/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/SearchQuery.java
+++ b/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/SearchQuery.java
@@ -50,14 +50,14 @@ public interface SearchQuery {
 
   /**
    * Returns the contextual site for this query.
-   * 
+   *
    * @return the site
    */
   Site getSite();
 
   /**
    * Sets the number of results that are returned.
-   * 
+   *
    * @param limit
    *          the number of results
    * @return the search query
@@ -68,7 +68,7 @@ public interface SearchQuery {
    * Returns the number of results that are returned, starting at the offset
    * returned by <code>getOffset()</code>. If no limit was specified, this
    * method returns <code>-1</code>.
-   * 
+   *
    * @return the maximum number of results
    */
   int getLimit();
@@ -77,7 +77,7 @@ public interface SearchQuery {
    * Sets the starting offset. Search results will be returned starting at that
    * offset and until the limit is reached, as specified by
    * <code>getLimit()</code>.
-   * 
+   *
    * @param offset
    *          the starting offset
    * @return the search query
@@ -88,7 +88,7 @@ public interface SearchQuery {
   /**
    * Returns the starting offset within the search result or <code>0</code> if
    * no offset was specified.
-   * 
+   *
    * @return the offset
    */
   int getOffset();
@@ -96,21 +96,21 @@ public interface SearchQuery {
   /**
    * Enables boosting based on creation/modification date of resources so that
    * recent documents are ranked higher than old ones.
-   * 
+   *
    * @return the search query
    */
   SearchQuery withRececyPriority();
 
   /**
    * Returns whether priority boosting has been enabled.
-   * 
+   *
    * @return <code>true</code> if recent documents are ranked higher
    */
   boolean getRecencyPriority();
 
   /**
    * Return the resources with the given identifier.
-   * 
+   *
    * @param resourceId
    *          the identifier to look up
    * @return the query extended by this criterion
@@ -119,14 +119,14 @@ public interface SearchQuery {
 
   /**
    * Returns the identifier or <code>null</code> if no identifier was specified.
-   * 
+   *
    * @return the identifier
    */
   String[] getIdentifier();
 
   /**
    * Return the resources with the given path.
-   * 
+   *
    * @param path
    *          the path to look up
    * @return the query extended by this criterion
@@ -135,14 +135,14 @@ public interface SearchQuery {
 
   /**
    * Returns the path or <code>null</code> if no path was specified.
-   * 
+   *
    * @return the path
    */
   String getPath();
 
   /**
    * Return the resources with the given template.
-   * 
+   *
    * @param template
    *          the template to look up
    * @return the query extended by this criterion
@@ -151,28 +151,28 @@ public interface SearchQuery {
 
   /**
    * Returns the template or <code>null</code> if no template was specified.
-   * 
+   *
    * @return the template
    */
   String getTemplate();
 
   /**
    * Return resources which are marked as stationaries.
-   * 
+   *
    * @return the query extended by this criterion
    */
   SearchQuery withStationary();
 
   /**
    * Returns <code>true</code> if stationary resources should be included.
-   * 
+   *
    * @return <code>true</code> to include stationaries
    */
   boolean isStationary();
 
   /**
    * Return the resources with the given source.
-   * 
+   *
    * @param source
    *          the source to look up
    * @return the query extended by this criterion
@@ -189,7 +189,7 @@ public interface SearchQuery {
   /**
    * Return the resources which have an external representation at the given
    * url.
-   * 
+   *
    * @param source
    *          the source to look up
    * @return the query extended by this criterion
@@ -199,14 +199,14 @@ public interface SearchQuery {
   /**
    * Returns the source or <code>null</code> if no external location was
    * specified.
-   * 
+   *
    * @return the source
    */
   URL getExternalLocation();
 
   /**
    * Return the resources with the given layout.
-   * 
+   *
    * @param layout
    *          the layout to look up
    * @return the query extended by this criterion
@@ -215,14 +215,30 @@ public interface SearchQuery {
 
   /**
    * Returns the layout or <code>null</code> if no layout was specified.
-   * 
+   *
    * @return the layout
    */
   String getLayout();
 
   /**
+   * Return the resources with the given flavor.
+   *
+   * @param flavor
+   *          the flavor to look up
+   * @return the query extended by this criterion
+   */
+  SearchQuery withFlavor(String flavor);
+
+  /**
+   * Returns the flavor or {@code null} if no flavor was specified.
+   *
+   * @return the flavor
+   */
+  String getFlavor();
+
+  /**
    * Return the resources with the given types.
-   * 
+   *
    * @param types
    *          the resource types to look up
    * @return the query extended by this criterion
@@ -231,7 +247,7 @@ public interface SearchQuery {
 
   /**
    * Returns the resources except the ones with the given types.
-   * 
+   *
    * @param types
    *          the resource types to block
    * @return the query extended by this criterion
@@ -240,7 +256,7 @@ public interface SearchQuery {
 
   /**
    * Returns the resource types or or an empty array if no types was specified.
-   * 
+   *
    * @return the type
    */
   String[] getTypes();
@@ -248,7 +264,7 @@ public interface SearchQuery {
   /**
    * Returns the blocked resource types or or an empty array if no types was
    * specified.
-   * 
+   *
    * @return the type
    */
   String[] getWithoutTypes();
@@ -256,7 +272,7 @@ public interface SearchQuery {
   /**
    * Return resources that contain the given text either in the page header or
    * in one of the pagelets.
-   * 
+   *
    * @param text
    *          the text to look up
    * @return the query extended by this criterion
@@ -266,12 +282,12 @@ public interface SearchQuery {
   /**
    * Return resources that contain the given text either in the page header or
    * in one of the pagelets.
-   * 
+   *
    * @param wildcardSearch
    *          <code>True</code> to perform a (much slower) wildcard search
    * @param text
    *          the text to look up
-   * 
+   *
    * @return the query extended by this criterion
    */
   SearchQuery withText(boolean wildcardSearch, String text);
@@ -282,7 +298,7 @@ public interface SearchQuery {
    * <p>
    * Depending on the quantifier, either resources are returned that contain at
    * least one of the terms are only resources containing all of the terms.
-   * 
+   *
    * @param text
    *          the text to look up
    * @param quantifier
@@ -295,14 +311,14 @@ public interface SearchQuery {
 
   /**
    * Returns the search terms or an empty collection if no terms were specified.
-   * 
+   *
    * @return the terms
    */
   Collection<SearchTerms<String>> getTerms();
 
   /**
    * Returns the search text or <code>null</code> if no text was specified.
-   * 
+   *
    * @return the text
    */
   String getQueryString();
@@ -312,7 +328,7 @@ public interface SearchQuery {
    * <p>
    * Note that this search field is not intended to serve frontend applications
    * but rather backend purposes.
-   * 
+   *
    * @param text
    *          the text to look up
    * @return the query extended by this criterion
@@ -324,12 +340,12 @@ public interface SearchQuery {
    * <p>
    * Note that this search field is not intended to serve frontend applications
    * but rather backend purposes.
-   * 
+   *
    * @param fuzzy
    *          <code>true</code> to perform a fuzzy search
    * @param text
    *          the text to look up
-   * 
+   *
    * @return the query extended by this criterion
    */
   SearchQuery withFulltext(boolean fuzzy, String text);
@@ -339,7 +355,7 @@ public interface SearchQuery {
    * <p>
    * Note that this search field is not intended to serve frontend applications
    * but rather backend purposes.
-   * 
+   *
    * @param fuzzy
    *          <code>true</code> to perform a fuzzy search
    * @param quantifier
@@ -354,7 +370,7 @@ public interface SearchQuery {
   /**
    * Returns the fulltext search terms or <code>null</code> if no text was
    * specified.
-   * 
+   *
    * @return the text
    */
   Collection<SearchTerms<String>> getFulltext();
@@ -362,7 +378,7 @@ public interface SearchQuery {
   /**
    * Returns <code>true</code> if the current search operation should be
    * performed using fuzzy searching.
-   * 
+   *
    * @return <code>true</code> if fzzy search should be used
    */
   boolean isFuzzySearch();
@@ -370,7 +386,7 @@ public interface SearchQuery {
   /**
    * Returns resources that match the search query <i>and</i> and the text
    * filter.
-   * 
+   *
    * @param filter
    *          the filter text
    * @return the search query
@@ -379,14 +395,14 @@ public interface SearchQuery {
 
   /**
    * Returns the filter expression.
-   * 
+   *
    * @return the filter
    */
   String getFilter();
 
   /**
    * Specifies an element within a pagelet.
-   * 
+   *
    * @param element
    *          the element name
    * @param value
@@ -398,14 +414,14 @@ public interface SearchQuery {
   /**
    * Returns the elements text or <code>null</code> if no elements were
    * specified.
-   * 
+   *
    * @return the text
    */
   Map<String, String> getElements();
 
   /**
    * Sets the properties and their values to search for.
-   * 
+   *
    * @param property
    *          the property name
    * @param value
@@ -417,14 +433,14 @@ public interface SearchQuery {
   /**
    * Returns the properties and their values or <code>null</code> if no
    * properties were specified.
-   * 
+   *
    * @return the properties
    */
   Map<String, String> getProperties();
 
   /**
    * Return only resources with hits in the specified language.
-   * 
+   *
    * @param language
    *          the language
    * @return the query extended by this criterion
@@ -433,14 +449,14 @@ public interface SearchQuery {
 
   /**
    * Returns the language or <code>null</code> if no language was specified.
-   * 
+   *
    * @return the language
    */
   Language getLanguage();
 
   /**
    * Only returns resources that contain the specified subject.
-   * 
+   *
    * @param subject
    *          the subject
    * @return the query extended by this criterion
@@ -451,12 +467,12 @@ public interface SearchQuery {
    * Returns only resources that match the given subjects. Depending on
    * <code>quantifier</code>, either all or some of the terms need to be
    * present.
-   * 
+   *
    * @param quantifier
    *          the quantifier
    * @param subjects
    *          the list of subjects
-   * 
+   *
    * @return the query extended by this criterion
    */
   SearchQuery withSubjects(Quantifier quantifier, String... subjects);
@@ -464,7 +480,7 @@ public interface SearchQuery {
   /**
    * Returns the subjects as a collection of search terms or <code>null</code>
    * if no subjects have been specified.
-   * 
+   *
    * @return the subjects
    */
   Collection<SearchTerms<String>> getSubjects();
@@ -473,7 +489,7 @@ public interface SearchQuery {
    * Only returns resources that contain the specified series. Note that this
    * method may be called multiple times in order to specify more than one
    * series.
-   * 
+   *
    * @param series
    *          the series
    * @return the query extended by this criterion
@@ -482,7 +498,7 @@ public interface SearchQuery {
 
   /**
    * Returns the series or an empty array if no series have been specified.
-   * 
+   *
    * @return the series
    */
   String[] getSeries();
@@ -490,7 +506,7 @@ public interface SearchQuery {
   /**
    * Return only resources that have been created or modified by the specified
    * author.
-   * 
+   *
    * @param author
    *          the author
    * @return the query extended by this criterion
@@ -499,14 +515,14 @@ public interface SearchQuery {
 
   /**
    * Returns the author or <code>null</code> if no author has been specified.
-   * 
+   *
    * @return the author
    */
   User getAuthor();
 
   /**
    * Return only resources that have been created by the specified user.
-   * 
+   *
    * @param creator
    *          the creator
    * @return the query extended by this criterion
@@ -515,14 +531,14 @@ public interface SearchQuery {
 
   /**
    * Returns the creator or <code>null</code> if no creator has been specified.
-   * 
+   *
    * @return the creator
    */
   User getCreator();
 
   /**
    * Return only resources that have been modified by the specified user.
-   * 
+   *
    * @param modifier
    *          the modifier
    * @return the query extended by this criterion
@@ -532,7 +548,7 @@ public interface SearchQuery {
   /**
    * Returns the modifier or <code>null</code> if no modifier has been
    * specified.
-   * 
+   *
    * @return the modifier
    */
   User getModifier();
@@ -543,21 +559,21 @@ public interface SearchQuery {
    * Note that this method throws an <code>IllegalStateException</code> if used
    * in conjunction with {@link #withPublishingDate(Date)},
    * {@link #withPublishingDateBetween(Date)} or {@link #and(Date)}.
-   * 
+   *
    * @return the query extended by this criterion
    */
   SearchQuery withoutPublication();
 
   /**
    * Returns <code>true</code> if resources must not have a publishing date.
-   * 
+   *
    * @return <code>true</code> if resources need to be unpublished
    */
   boolean getWithoutPublication();
 
   /**
    * Return only resources that have been published by the specified publisher.
-   * 
+   *
    * @param publisher
    *          the publisher
    * @return the query extended by this criterion
@@ -567,7 +583,7 @@ public interface SearchQuery {
   /**
    * Returns the publisher or <code>null</code> if no publisher has been
    * specified.
-   * 
+   *
    * @return the publisher
    */
   User getPublisher();
@@ -578,7 +594,7 @@ public interface SearchQuery {
    * Note that this method throws an <code>IllegalStateException</code> if used
    * in conjunction with {@link #withPublishingDateBetween(Date)} or
    * {@link #and(Date)}.
-   * 
+   *
    * @param date
    *          the publishing date
    * @return the query extended by this criterion
@@ -590,7 +606,7 @@ public interface SearchQuery {
    * <p>
    * Note that this method cannot be used without a subsequent call to
    * {@link #and(Date)} in order to specify the end date.
-   * 
+   *
    * @param date
    *          the publishing start date
    * @return the query extended by this criterion
@@ -600,7 +616,7 @@ public interface SearchQuery {
   /**
    * Returns the publishing date or <code>null</code> if no publishing date has
    * been specified.
-   * 
+   *
    * @return the publishing date
    */
   Date getPublishingDate();
@@ -608,7 +624,7 @@ public interface SearchQuery {
   /**
    * Returns the end of the range for the publishing date or <code>null</code>
    * if no end date has been specified.
-   * 
+   *
    * @return the publishing end date
    */
   Date getPublishingDateEnd();
@@ -619,14 +635,14 @@ public interface SearchQuery {
    * Note that this method throws an <code>IllegalStateException</code> if used
    * in conjunction with {@link #withModificationDate(Date)},
    * {@link #withModificationDateBetween(Date)} or {@link #and(Date)}.
-   * 
+   *
    * @return the query extended by this criterion
    */
   SearchQuery withoutModification();
 
   /**
    * Returns <code>true</code> if resources must not have a modification date.
-   * 
+   *
    * @return <code>true</code> if resources need to be unmodified
    */
   boolean getWithoutModification();
@@ -637,7 +653,7 @@ public interface SearchQuery {
    * Note that this method throws an <code>IllegalStateException</code> if used
    * in conjunction with {@link #withModificationDateBetween(Date)} or
    * {@link #and(Date)}.
-   * 
+   *
    * @param date
    *          the modification date
    * @return the query extended by this criterion
@@ -649,7 +665,7 @@ public interface SearchQuery {
    * <p>
    * Note that this method cannot be used without a subsequent call to
    * {@link #and(Date)} in order to specify the end date.
-   * 
+   *
    * @param date
    *          the modification start date
    * @return the query extended by this criterion
@@ -659,7 +675,7 @@ public interface SearchQuery {
   /**
    * Returns the modification date or <code>null</code> if no modification date
    * has been specified.
-   * 
+   *
    * @return the modification date
    */
   Date getModificationDate();
@@ -667,7 +683,7 @@ public interface SearchQuery {
   /**
    * Returns the end of the range for the modification date or <code>null</code>
    * if no end date has been specified.
-   * 
+   *
    * @return the modification end date
    */
   Date getModificationDateEnd();
@@ -678,7 +694,7 @@ public interface SearchQuery {
    * Note that this method throws an <code>IllegalStateException</code> if used
    * in conjunction with {@link #withCreationDateBetween(Date)} or
    * {@link #and(Date)}.
-   * 
+   *
    * @param date
    *          the Creation date
    * @return the query extended by this criterion
@@ -690,7 +706,7 @@ public interface SearchQuery {
    * <p>
    * Note that this method cannot be used without a subsequent call to
    * {@link #and(Date)} in order to specify the end date.
-   * 
+   *
    * @param date
    *          the Creation start date
    * @return the query extended by this criterion
@@ -700,7 +716,7 @@ public interface SearchQuery {
   /**
    * Returns the creation date or <code>null</code> if no creation date has been
    * specified.
-   * 
+   *
    * @return the creation date
    */
   Date getCreationDate();
@@ -708,7 +724,7 @@ public interface SearchQuery {
   /**
    * Returns the end of the range for the creation date or <code>null</code> if
    * no end date has been specified.
-   * 
+   *
    * @return the creation end date
    */
   Date getCreationDateEnd();
@@ -718,7 +734,7 @@ public interface SearchQuery {
    * to either one of {@link #withPublishingDateBetween(Date)},
    * {@link #withModificationDateBetween(Date)} or
    * {@link #withCreationDateBetween(Date)}.
-   * 
+   *
    * @param date
    *          the end date
    * @return the query extended by this criterion
@@ -727,7 +743,7 @@ public interface SearchQuery {
 
   /**
    * Return only resources that have been locked by the specified user.
-   * 
+   *
    * @param lockOwner
    *          the user holding the lock
    * @return the query extended by this criterion
@@ -736,7 +752,7 @@ public interface SearchQuery {
 
   /**
    * Return only resources that have been locked by somebody.
-   * 
+   *
    * @return the query extended by this criterion
    */
   SearchQuery withLockOwner();
@@ -744,7 +760,7 @@ public interface SearchQuery {
   /**
    * Returns the lock owner or <code>null</code> if no lock owner has been
    * specified.
-   * 
+   *
    * @return the lock owner
    */
   User getLockOwner();
@@ -752,7 +768,7 @@ public interface SearchQuery {
   /**
    * Only return resources that are located on or below the given path in the
    * page tree.
-   * 
+   *
    * @param path
    *          the path in the site tree
    * @return the query extended by this criterion
@@ -761,7 +777,7 @@ public interface SearchQuery {
 
   /**
    * Returns the path prefix.
-   * 
+   *
    * @return the prefix
    */
   String getPathPrefix();
@@ -774,7 +790,7 @@ public interface SearchQuery {
    * {@link #inComposer(String)} {@link #atPosition(int)},
    * {@link #andElement(String, String)} and
    * {@link #andProperty(String, String)}.
-   * 
+   *
    * @param pagelet
    *          the pagelet
    * @return the query extended by this criterion
@@ -789,7 +805,7 @@ public interface SearchQuery {
    * {@link #inComposer(String)} {@link #atPosition(int)},
    * {@link #andElement(String, String)} and
    * {@link #andProperty(String, String)}.
-   * 
+   *
    * @param pagelets
    *          the pagelets
    * @return the query extended by this criterion
@@ -800,7 +816,7 @@ public interface SearchQuery {
    * Returns the list of required pagelets, along with their elements,
    * properties and location information as a collection of search terms or
    * <code>null</code> if not pagelets have been specified.
-   * 
+   *
    * @return the pagelets
    */
   Collection<SearchTerms<Pagelet>> getPagelets();
@@ -808,7 +824,7 @@ public interface SearchQuery {
   /**
    * This method may be called after a call to {@link #withPagelet(Pagelet)} in
    * order to specify the composer that the pagelet needs to be in.
-   * 
+   *
    * @param composer
    *          the composer name
    * @return the query extended by this criterion
@@ -820,7 +836,7 @@ public interface SearchQuery {
   /**
    * This method may be called after a call to {@link #withPagelet(Pagelet)} in
    * order to specify that the pagelet needs to be in the stage composer.
-   * 
+   *
    * @return the query extended by this criterion
    * @throws IllegalStateException
    *           if no pagelet has been specified before
@@ -830,7 +846,7 @@ public interface SearchQuery {
   /**
    * This method may be called after a call to {@link #inComposer(String)} in
    * order to specify the pagelet's position within that composer.
-   * 
+   *
    * @param position
    *          the pagelet position within the composer
    * @return the query extended by this criterion
@@ -847,12 +863,12 @@ public interface SearchQuery {
    * Note that the property value needs to match exactly. Also, you need to
    * specify the pagelet right before calling this method, otherwise an
    * <code>IllegalStateException</code> will be thrown:
-   * 
+   *
    * <pre>
    * SearchQuery q = new SearchQuery();
    * q.withPagelet(p).andProperty(&quot;hello&quot;, &quot;world&quot;);
    * </pre>
-   * 
+   *
    * @param propertyName
    *          name of the property
    * @param propertyValue
@@ -872,12 +888,12 @@ public interface SearchQuery {
    * Note that partial matches are considered a hit as well. Also, you need to
    * specify the pagelet right before calling this method, otherwise an
    * <code>IllegalStateException</code> will be thrown:
-   * 
+   *
    * <pre>
    * SearchQuery q = new SearchQuery();
    * q.withPagelet(p).andProperty(&quot;hello&quot;, &quot;world&quot;);
    * </pre>
-   * 
+   *
    * @param textName
    *          name of the text field
    * @param text
@@ -891,7 +907,7 @@ public interface SearchQuery {
 
   /**
    * Return the resources with the given filename in their content section.
-   * 
+   *
    * @param filename
    *          the filename to look up
    * @return the query extended by this criterion
@@ -900,14 +916,14 @@ public interface SearchQuery {
 
   /**
    * Returns the filename or <code>null</code> if no filename was specified.
-   * 
+   *
    * @return the filename
    */
   String getFilename();
 
   /**
    * Return the resources with the given mime type in their content section.
-   * 
+   *
    * @param mimetype
    *          the mime type to look up
    * @return the query extended by this criterion
@@ -916,7 +932,7 @@ public interface SearchQuery {
 
   /**
    * Returns the mime type or <code>null</code> if no mime type was specified.
-   * 
+   *
    * @return the mime type
    */
   String getMimetype();
@@ -924,7 +940,7 @@ public interface SearchQuery {
   /**
    * Asks the search index to order the results by creation date rather than by
    * relevance.
-   * 
+   *
    * @param order
    *          the sort order
    * @return the search query
@@ -934,7 +950,7 @@ public interface SearchQuery {
   /**
    * Returns the sort order for the date if specified. If this field is not to
    * be sorted by creation date, {@link Order#None} is returned.
-   * 
+   *
    * @return the sort order
    */
   Order getCreationDateSortOrder();
@@ -942,7 +958,7 @@ public interface SearchQuery {
   /**
    * Asks the search index to order the results by modification date rather than
    * by relevance.
-   * 
+   *
    * @param order
    *          the sort order
    * @return the search query
@@ -952,7 +968,7 @@ public interface SearchQuery {
   /**
    * Returns the sort order for the date if specified. If this field is not to
    * be sorted by modification date, {@link Order#None} is returned.
-   * 
+   *
    * @return the sort order
    */
   Order getModificationDateSortOrder();
@@ -960,7 +976,7 @@ public interface SearchQuery {
   /**
    * Asks the search index to order the results by publishing date rather than
    * by relevance.
-   * 
+   *
    * @param order
    *          the sort order
    * @return the search query
@@ -970,14 +986,14 @@ public interface SearchQuery {
   /**
    * Returns the sort order for the date if specified. If this field is not to
    * be sorted by publishing date, {@link Order#None} is returned.
-   * 
+   *
    * @return the sort order
    */
   Order getPublishingDateSortOrder();
 
   /**
    * Asks the search index to return only resources with the indicated version.
-   * 
+   *
    * @param version
    *          the version
    * @return the search query
@@ -987,7 +1003,7 @@ public interface SearchQuery {
   /**
    * Asks the search index to return only resources with the indicated version
    * if available else return the available version.
-   * 
+   *
    * @param preferredVersion
    *          the preferredVersion
    * @return the search query
@@ -996,14 +1012,14 @@ public interface SearchQuery {
 
   /**
    * Returns the resource version.
-   * 
+   *
    * @return the version
    */
   long getVersion();
 
   /**
    * Return the preferred resource version.
-   * 
+   *
    * @return the preferred version
    */
   long getPreferredVersion();
@@ -1011,7 +1027,7 @@ public interface SearchQuery {
   /**
    * Returns the fields that should be returned by the query. If all fields
    * should be returned, the method will return an empty array.
-   * 
+   *
    * @return the names of the fields to return
    */
   String[] getFields();
@@ -1019,7 +1035,7 @@ public interface SearchQuery {
   /**
    * Adds a field that needs to be returned by the query. If no fields are being
    * set, all fields will be returned.
-   * 
+   *
    * @param field
    *          the field name
    * @return the query
@@ -1029,7 +1045,7 @@ public interface SearchQuery {
   /**
    * Adds the fields that need to be returned by the query. If no fields are
    * being set, all fields will be returned.
-   * 
+   *
    * @param fields
    *          the field names
    * @return the query

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/AbstractResourceReaderImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/AbstractResourceReaderImpl.java
@@ -346,9 +346,9 @@ public abstract class AbstractResourceReaderImpl<S extends ResourceContent, T ex
         resource.setPromoted("true".equals(characters.toString()));
       }
 
-      // Type
-      else if ("type".equals(raw)) {
-        resource.setType(characters.toString());
+      // Flavor
+      else if ("flavor".equals(raw)) {
+        resource.setFlavor(characters.toString());
       }
 
       // Title

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/AbstractResourceSearchResultItemImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/AbstractResourceSearchResultItemImpl.java
@@ -77,15 +77,6 @@ public abstract class AbstractResourceSearchResultItemImpl extends SearchResultI
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.SearchResultItem#getType()
-   */
-  public String getType() {
-    return uri.getType();
-  }
-
-  /**
-   * {@inheritDoc}
-   * 
    * @see ch.entwine.weblounge.common.content.ResourceSearchResultItem#getMetadata()
    */
   public List<ResourceMetadata<?>> getMetadata() {

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/ResourceImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/ResourceImpl.java
@@ -67,7 +67,7 @@ public abstract class ResourceImpl<T extends ResourceContent> extends Localizabl
   protected ResourceURI uri = null;
 
   /** Resource type */
-  protected String type = null;
+  protected String flavor = null;
 
   /** Keywords */
   protected List<String> subjects = null;
@@ -156,22 +156,21 @@ public abstract class ResourceImpl<T extends ResourceContent> extends Localizabl
   }
 
   /**
-   * Returns the resource type.
+   * {@inheritDoc}
    * 
-   * @return the resource type
+   * @see ch.entwine.weblounge.common.content.Resource#getFlavor()
    */
-  public String getType() {
-    return type;
+  public String getFlavor() {
+    return flavor;
   }
 
   /**
-   * Sets the page type: news, feature, ...
+   * {@inheritDoc}
    * 
-   * @param type
-   *          the resource type
+   * @see ch.entwine.weblounge.common.content.Resource#setFlavor()
    */
-  public void setType(String type) {
-    this.type = type;
+  public void setFlavor(String flavor) {
+    this.flavor = flavor;
   }
 
   /**
@@ -1075,11 +1074,11 @@ public abstract class ResourceImpl<T extends ResourceContent> extends Localizabl
       b.append("]]></series>");
     }
 
-    // Type
-    if (type != null) {
-      b.append("<type><![CDATA[");
-      b.append(type);
-      b.append("]]></type>");
+    // Flavor
+    if (flavor != null) {
+      b.append("<flavor><![CDATA[");
+      b.append(flavor);
+      b.append("]]></flavor>");
     }
 
     // Coverage

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/SearchQueryImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/SearchQueryImpl.java
@@ -92,6 +92,9 @@ public class SearchQueryImpl implements SearchQuery {
   /** The layout */
   protected String layout = null;
 
+  /* The flavor */
+  protected String flavor = null;
+
   /** Stationary flag */
   protected boolean stationary = false;
 
@@ -410,6 +413,27 @@ public class SearchQueryImpl implements SearchQuery {
    */
   public String getLayout() {
     return layout;
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.SearchQuery#withFlavor(java.lang.String)
+   */
+  @Override
+  public SearchQuery withFlavor(String flavor) {
+    this.flavor = flavor;
+    return this;
+  }
+
+  /**
+   * {@inheritDoc}
+   * 
+   * @see ch.entwine.weblounge.common.content.SearchQuery#getFlavor()
+   */
+  @Override
+  public String getFlavor() {
+    return flavor;
   }
 
   /**

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/SearchQueryImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/SearchQueryImpl.java
@@ -458,7 +458,7 @@ public class SearchQueryImpl implements SearchQuery {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.SearchQuery#getType()
+   * @see ch.entwine.weblounge.common.content.SearchQuery#getTypes()
    */
   public String[] getTypes() {
     return types.toArray(new String[types.size()]);

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/file/LazyFileResourceImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/file/LazyFileResourceImpl.java
@@ -423,18 +423,18 @@ public class LazyFileResourceImpl implements FileResource {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.file.Page#getType()
+   * @see ch.entwine.weblounge.common.content.Resource#getFlavor()
    */
-  public String getType() {
+  public String getFlavor() {
     if (!isHeaderLoaded)
       loadFileHeader();
-    return file.getType();
+    return file.getFlavor();
   }
 
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.file.Page#getResourceURI()
+   * @see ch.entwine.weblounge.common.content.Resource#getResourceURI()
    */
   public ResourceURI getURI() {
     return uri;
@@ -633,12 +633,12 @@ public class LazyFileResourceImpl implements FileResource {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.file.Page#setType(java.lang.String)
+   * @see ch.entwine.weblounge.common.content.Resource#setFlavor(java.lang.String)
    */
-  public void setType(String type) {
+  public void setFlavor(String flavor) {
     if (!isHeaderLoaded)
       loadFileHeader();
-    file.setType(type);
+    file.setFlavor(flavor);
   }
 
   /**

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/image/LazyImageResourceImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/image/LazyImageResourceImpl.java
@@ -406,7 +406,7 @@ public class LazyImageResourceImpl implements ImageResource {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.image.Page#getTitle(ch.entwine.weblounge.common.language.Language,
+   * @see ch.entwine.weblounge.common.content.Resource#getTitle(ch.entwine.weblounge.common.language.Language,
    *      boolean)
    */
   public String getTitle(Language language, boolean force) {
@@ -418,18 +418,18 @@ public class LazyImageResourceImpl implements ImageResource {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.image.Page#getType()
+   * @see ch.entwine.weblounge.common.content.Resource#getFlavor()
    */
-  public String getType() {
+  public String getFlavor() {
     if (!isHeaderLoaded)
       loadImageHeader();
-    return image.getType();
+    return image.getFlavor();
   }
 
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.image.Page#getResourceURI()
+   * @see ch.entwine.weblounge.common.content.Resource#getResourceURI()
    */
   public ResourceURI getURI() {
     return uri;
@@ -628,12 +628,12 @@ public class LazyImageResourceImpl implements ImageResource {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.image.Page#setType(java.lang.String)
+   * @see ch.entwine.weblounge.common.content.Resource#setFlavor(java.lang.String)
    */
-  public void setType(String type) {
+  public void setFlavor(String flavor) {
     if (!isHeaderLoaded)
       loadImageHeader();
-    image.setType(type);
+    image.setFlavor(flavor);
   }
 
   /**

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/movie/LazyMovieResourceImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/movie/LazyMovieResourceImpl.java
@@ -419,12 +419,12 @@ public class LazyMovieResourceImpl implements MovieResource {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.Resource#getType()
+   * @see ch.entwine.weblounge.common.content.Resource#getFlavor()
    */
-  public String getType() {
+  public String getFlavor() {
     if (!isHeaderLoaded)
       loadAudioVisualHeader();
-    return audioVisual.getType();
+    return audioVisual.getFlavor();
   }
 
   /**
@@ -629,12 +629,12 @@ public class LazyMovieResourceImpl implements MovieResource {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.Resource#setType(java.lang.String)
+   * @see ch.entwine.weblounge.common.content.Resource#setFlavor(java.lang.String)
    */
-  public void setType(String type) {
+  public void setFlavor(String flavor) {
     if (!isHeaderLoaded)
       loadAudioVisualHeader();
-    audioVisual.setType(type);
+    audioVisual.setFlavor(flavor);
   }
 
   /**

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/LazyPageImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/LazyPageImpl.java
@@ -572,7 +572,7 @@ public class LazyPageImpl implements Page {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.page.Page#getTitle(ch.entwine.weblounge.common.language.Language,
+   * @see ch.entwine.weblounge.common.content.Resource#getTitle(ch.entwine.weblounge.common.language.Language,
    *      boolean)
    */
   public String getTitle(Language language, boolean force) {
@@ -584,18 +584,18 @@ public class LazyPageImpl implements Page {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.page.Page#getType()
+   * @see ch.entwine.weblounge.common.content.Resource#getFlavor()
    */
-  public String getType() {
+  public String getFlavor() {
     if (!isHeaderLoaded)
       loadPageHeader();
-    return page.getType();
+    return page.getFlavor();
   }
 
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.page.Page#getURI()
+   * @see ch.entwine.weblounge.common.content.Resource#getURI()
    */
   public ResourceURI getURI() {
     return uri;
@@ -884,18 +884,18 @@ public class LazyPageImpl implements Page {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.page.Page#setType(java.lang.String)
+   * @see ch.entwine.weblounge.common.content.Resource#setFlavor(java.lang.String)
    */
-  public void setType(String type) {
+  public void setFlavor(String flavor) {
     if (!isHeaderLoaded)
       loadPageHeader();
-    page.setType(type);
+    page.setFlavor(flavor);
   }
 
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.page.Page#unlock()
+   * @see ch.entwine.weblounge.common.content.Resource#unlock()
    */
   public User unlock() {
     if (!isHeaderLoaded)
@@ -915,7 +915,7 @@ public class LazyPageImpl implements Page {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.page.Page#toXml()
+   * @see ch.entwine.weblounge.common.content.Resource#toXml()
    */
   public String toXml() {
     if (!isBodyLoaded)

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/MockPageImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/MockPageImpl.java
@@ -96,18 +96,18 @@ public class MockPageImpl implements Page {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.Resource#setType(java.lang.String)
+   * @see ch.entwine.weblounge.common.content.Resource#setFlavor(java.lang.String)
    */
-  public void setType(String type) {
-    uri.setType(type);
+  public void setFlavor(String flavor) {
+    uri.setType(flavor);
   }
 
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.Resource#getType()
+   * @see ch.entwine.weblounge.common.content.Resource#getFlavor()
    */
-  public String getType() {
+  public String getFlavor() {
     return uri.getType();
   }
 

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/PageReader.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/page/PageReader.java
@@ -409,8 +409,8 @@ public class PageReader extends WebloungeContentReader implements ResourceReader
       }
 
       // Type
-      else if ("type".equals(raw)) {
-        page.setType(getCharacters());
+      else if ("flavor".equals(raw)) {
+        page.setFlavor(getCharacters());
       }
 
       // Title

--- a/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/file/FileImplTest.java
+++ b/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/file/FileImplTest.java
@@ -72,8 +72,8 @@ public class FileImplTest {
   /** The site */
   protected Site site = null;
 
-  /** The file type */
-  protected String fileType = "File";
+  /** The file flavor */
+  protected String fileFlavor = "Letter";
 
   /** Anchor file */
   protected boolean isPromoted = true;
@@ -170,7 +170,7 @@ public class FileImplTest {
     file.setRights(germanRights, german);
     file.setTitle(germanTitle, german);
     file.setTitle(frenchTitle, french);
-    file.setType(fileType);
+    file.setFlavor(fileFlavor);
     for (String subject : subjects)
       file.addSubject(subject);
     for (String series : this.series)
@@ -209,12 +209,12 @@ public class FileImplTest {
 
   /**
    * Test method for
-   * {@link ch.entwine.weblounge.common.impl.content.file.FileResourceImpl#getType()}
+   * {@link ch.entwine.weblounge.common.impl.content.file.FileResourceImpl#getFlavor()}
    * .
    */
   @Test
   public void testGetType() {
-    assertEquals(fileType, file.getType());
+    assertEquals(fileFlavor, file.getFlavor());
   }
 
   /**

--- a/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/page/PageImplTest.java
+++ b/modules/weblounge-common/src/test/java/ch/entwine/weblounge/common/impl/content/page/PageImplTest.java
@@ -70,8 +70,8 @@ public class PageImplTest {
   /** The site */
   protected Site site = null;
   
-  /** The page type */
-  protected String pageType = "Text";
+  /** The page flavor */
+  protected String pageFlavor = "Text";
 
   /** The page template */
   protected String template = "home";
@@ -164,7 +164,7 @@ public class PageImplTest {
     page.setTemplate(template);
     page.setTitle(germanTitle, german);
     page.setTitle(frenchTitle, french);
-    page.setType(pageType);
+    page.setFlavor(pageFlavor);
     for (String subject : subjects)
       page.addSubject(subject);
     page.addPagelet(new PageletImpl(module, pagelet), composer);
@@ -195,11 +195,11 @@ public class PageImplTest {
   }
 
   /**
-   * Test method for {@link ch.entwine.weblounge.common.impl.content.page.PageImpl#getType()}.
+   * Test method for {@link ch.entwine.weblounge.common.impl.content.page.PageImpl#getFlavor()}.
    */
   @Test
   public void testGetType() {
-    assertEquals(pageType, page.getType());
+    assertEquals(pageFlavor, page.getFlavor());
   }
 
   /**

--- a/modules/weblounge-common/src/test/resources/file.xml
+++ b/modules/weblounge-common/src/test/resources/file.xml
@@ -12,7 +12,7 @@
       <subject><![CDATA[This subject]]></subject>
       <series><![CDATA[233-0326-11L]]></series>
       <series><![CDATA[252-0206-00L]]></series>
-      <type><![CDATA[File]]></type>
+      <flavor><![CDATA[Letter]]></flavor>
       <coverage language="de"><![CDATA[Zürich]]></coverage>
       <coverage language="fr"><![CDATA[Zurich]]></coverage>
       <rights language="de"><![CDATA[Copyright 2009 by T. Wunden]]></rights>

--- a/modules/weblounge-common/src/test/resources/file2.xml
+++ b/modules/weblounge-common/src/test/resources/file2.xml
@@ -10,7 +10,7 @@
       <description language="fr"><![CDATA[Déscription]]></description>
       <subject><![CDATA[This subject]]></subject>
       <subject><![CDATA[Topic a]]></subject>
-      <type><![CDATA[Text]]></type>
+      <flavor><![CDATA[Text]]></flavor>
       <coverage language="de"><![CDATA[Zürich]]></coverage>
       <coverage language="fr"><![CDATA[Zurich]]></coverage>
       <rights language="de"><![CDATA[Copyright 2009 by T. Wunden]]></rights>

--- a/modules/weblounge-common/src/test/resources/movie.xml
+++ b/modules/weblounge-common/src/test/resources/movie.xml
@@ -10,7 +10,7 @@
       <description language="fr"><![CDATA[Déscription]]></description>
       <subject><![CDATA[Other topic]]></subject>
       <subject><![CDATA[This subject]]></subject>
-      <type><![CDATA[File]]></type>
+      <flavor><![CDATA[File]]></flavor>
       <coverage language="de"><![CDATA[Zürich]]></coverage>
       <coverage language="fr"><![CDATA[Zurich]]></coverage>
       <rights language="de"><![CDATA[Copyright 2009 by T. Wunden]]></rights>

--- a/modules/weblounge-common/src/test/resources/page.xml
+++ b/modules/weblounge-common/src/test/resources/page.xml
@@ -13,7 +13,7 @@
       <description language="fr"><![CDATA[Déscription]]></description>
       <subject><![CDATA[Other topic]]></subject>
       <subject><![CDATA[This subject]]></subject>
-      <type><![CDATA[Text]]></type>
+      <flavor><![CDATA[Text]]></flavor>
       <coverage language="de"><![CDATA[Zürich]]></coverage>
       <coverage language="fr"><![CDATA[Zurich]]></coverage>
       <rights language="de"><![CDATA[Copyright 2009 by T. Wunden]]></rights>

--- a/modules/weblounge-common/src/test/resources/page2.xml
+++ b/modules/weblounge-common/src/test/resources/page2.xml
@@ -12,7 +12,7 @@
       <description language="fr"><![CDATA[Déscription]]></description>
       <subject><![CDATA[This subject]]></subject>
       <subject><![CDATA[Topic a]]></subject>
-      <type><![CDATA[Text]]></type>
+      <flavor><![CDATA[Text]]></flavor>
       <coverage language="de"><![CDATA[Zürich]]></coverage>
       <coverage language="fr"><![CDATA[Zurich]]></coverage>
       <rights language="de"><![CDATA[Copyright 2009 by T. Wunden]]></rights>

--- a/modules/weblounge-common/src/test/resources/pageheader.xml
+++ b/modules/weblounge-common/src/test/resources/pageheader.xml
@@ -12,7 +12,7 @@
       <description language="fr"><![CDATA[Déscription]]></description>
       <subject><![CDATA[Other topic]]></subject>
       <subject><![CDATA[This subject]]></subject>
-      <type><![CDATA[Text]]></type>
+      <flavor><![CDATA[Text]]></flavor>
       <coverage language="de"><![CDATA[Zürich]]></coverage>
       <coverage language="fr"><![CDATA[Zurich]]></coverage>
       <rights language="de"><![CDATA[Copyright 2009 by T. Wunden]]></rights>

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/ResourceSelectorImpl.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/ResourceSelectorImpl.java
@@ -163,7 +163,7 @@ public class ResourceSelectorImpl implements ResourceSelector {
   /**
    * {@inheritDoc}
    * 
-   * @see ch.entwine.weblounge.common.content.ResourceSelector#getType()
+   * @see ch.entwine.weblounge.common.content.ResourceSelector#getTypes()
    */
   public String[] getTypes() {
     return types.toArray(new String[types.size()]);

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/IndexSchema.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/IndexSchema.java
@@ -51,6 +51,9 @@ public interface IndexSchema {
 
   /** Template field name */
   String TEMPLATE = "template";
+  
+  /** Flavor field name */
+  String FLAVOR = "flavor";
 
   /** Stationary field name */
   String STATIONARY = "stationary";

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/ResourceInputDocument.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/ResourceInputDocument.java
@@ -36,6 +36,7 @@ import static ch.entwine.weblounge.search.impl.IndexSchema.CREATED_BY;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CREATED_BY_NAME;
 import static ch.entwine.weblounge.search.impl.IndexSchema.DESCRIPTION;
 import static ch.entwine.weblounge.search.impl.IndexSchema.DESCRIPTION_LOCALIZED;
+import static ch.entwine.weblounge.search.impl.IndexSchema.FLAVOR;
 import static ch.entwine.weblounge.search.impl.IndexSchema.HEADER_XML;
 import static ch.entwine.weblounge.search.impl.IndexSchema.LOCKED_BY;
 import static ch.entwine.weblounge.search.impl.IndexSchema.LOCKED_BY_NAME;
@@ -124,6 +125,8 @@ public class ResourceInputDocument extends ResourceMetadataCollection {
 
     for (String series : resource.getSeries())
       addField(SERIES, series, true, true);
+    
+    addField(FLAVOR, resource.getFlavor(), true, false);
 
     // Creation, modification and publishing information
     addField(OWNED_BY, IndexUtils.serializeUserId(resource.getOwner()), false, false);

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/elasticsearch/ElasticSearchSearchQuery.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/search/impl/elasticsearch/ElasticSearchSearchQuery.java
@@ -20,6 +20,7 @@
 
 package ch.entwine.weblounge.search.impl.elasticsearch;
 
+import static ch.entwine.weblounge.common.content.SearchQuery.Quantifier.All;
 import static ch.entwine.weblounge.search.impl.IndexSchema.ALTERNATE_VERSION;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_EXTERNAL_REPRESENTATION;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_FILENAME;
@@ -27,11 +28,14 @@ import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_MIMETYPE;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CONTENT_SOURCE;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CREATED;
 import static ch.entwine.weblounge.search.impl.IndexSchema.CREATED_BY;
+import static ch.entwine.weblounge.search.impl.IndexSchema.FLAVOR;
 import static ch.entwine.weblounge.search.impl.IndexSchema.FULLTEXT;
 import static ch.entwine.weblounge.search.impl.IndexSchema.FULLTEXT_FUZZY;
 import static ch.entwine.weblounge.search.impl.IndexSchema.LOCKED_BY;
 import static ch.entwine.weblounge.search.impl.IndexSchema.MODIFIED;
 import static ch.entwine.weblounge.search.impl.IndexSchema.MODIFIED_BY;
+import static ch.entwine.weblounge.search.impl.IndexSchema.ORIGIN;
+import static ch.entwine.weblounge.search.impl.IndexSchema.ORIGINAL_IDENTIFIER;
 import static ch.entwine.weblounge.search.impl.IndexSchema.PAGELET_PROPERTIES;
 import static ch.entwine.weblounge.search.impl.IndexSchema.PAGELET_TYPE;
 import static ch.entwine.weblounge.search.impl.IndexSchema.PAGELET_TYPE_COMPOSER;
@@ -49,8 +53,6 @@ import static ch.entwine.weblounge.search.impl.IndexSchema.TEXT;
 import static ch.entwine.weblounge.search.impl.IndexSchema.TEXT_FUZZY;
 import static ch.entwine.weblounge.search.impl.IndexSchema.TYPE;
 import static ch.entwine.weblounge.search.impl.IndexSchema.VERSION;
-
-import static ch.entwine.weblounge.common.content.SearchQuery.Quantifier.All;
 
 import ch.entwine.weblounge.common.content.SearchQuery;
 import ch.entwine.weblounge.common.content.SearchQuery.Quantifier;
@@ -140,7 +142,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
 
   /**
    * Creates a new elastic search query based on the Weblounge query.
-   * 
+   *
    * @param query
    *          the weblounge query
    */
@@ -151,7 +153,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
 
   /**
    * {@inheritDoc}
-   * 
+   *
    * @see org.elasticsearch.index.query.BaseQueryBuilder#doXContent(org.elasticsearch.common.xcontent.XContentBuilder,
    *      org.elasticsearch.common.xcontent.ToXContent.Params)
    */
@@ -210,6 +212,10 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
     // Template
     if (query.getTemplate() != null) {
       and(TEMPLATE, query.getTemplate(), true);
+    }
+
+    if (query.getFlavor() != null) {
+      and(FLAVOR, query.getFlavor(), true);
     }
 
     // Stationary
@@ -554,7 +560,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
   /**
    * Stores <code>fieldValue</code> as a search term on the
    * <code>fieldName</code> field.
-   * 
+   *
    * @param fieldName
    *          the field name
    * @param fieldValue
@@ -584,7 +590,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
   /**
    * Stores <code>fieldValues</code> as search terms on the
    * <code>fieldName</code> field.
-   * 
+   *
    * @param fieldName
    *          the field name
    * @param fieldValues
@@ -602,7 +608,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
   /**
    * Stores <code>fieldValue</code> as a search term on the
    * <code>fieldName</code> field.
-   * 
+   *
    * @param fieldName
    *          the field name
    * @param startDate
@@ -627,7 +633,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
   /**
    * Stores <code>fieldValue</code> as a negative search term on the
    * <code>fieldName</code> field.
-   * 
+   *
    * @param fieldName
    *          the field name
    * @param fieldValue
@@ -657,7 +663,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
   /**
    * Stores <code>fieldValues</code> as negative search terms on the
    * <code>fieldName</code> field.
-   * 
+   *
    * @param fieldName
    *          the field name
    * @param fieldValues
@@ -675,7 +681,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
   /**
    * Encodes the field name as part of the AND clause of a solr query:
    * <tt>AND -fieldName : [* TO *]</tt>.
-   * 
+   *
    * @param fieldName
    *          the field name
    */
@@ -688,7 +694,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
   /**
    * Encodes the field name as part of the AND clause of a solr query:
    * <tt>AND fieldName : ["" TO *]</tt>.
-   * 
+   *
    * @param fieldName
    *          the field name
    */
@@ -700,7 +706,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
 
   /**
    * {@inheritDoc}
-   * 
+   *
    * @see org.elasticsearch.common.xcontent.ToXContent#toXContent(org.elasticsearch.common.xcontent.XContentBuilder,
    *      org.elasticsearch.common.xcontent.ToXContent.Params)
    */
@@ -712,7 +718,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
 
   /**
    * {@inheritDoc}
-   * 
+   *
    * @see org.elasticsearch.index.query.QueryBuilder#buildAsBytes()
    */
   @Override
@@ -722,7 +728,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
 
   /**
    * {@inheritDoc}
-   * 
+   *
    * @see org.elasticsearch.index.query.QueryBuilder#buildAsBytes(org.elasticsearch.common.xcontent.XContentType)
    */
   @Override
@@ -749,7 +755,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
      * Creates a new date range specification with the given field name, start
      * and end dates. <code>null</code> may be passed in for start or end dates
      * that should remain unspecified.
-     * 
+     *
      * @param field
      *          the field name
      * @param start
@@ -765,7 +771,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
 
     /**
      * Returns the range query that is represented by this date range.
-     * 
+     *
      * @return the range query builder
      */
     QueryBuilder getQueryBuilder() {
@@ -779,7 +785,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
@@ -792,7 +798,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see java.lang.Object#hashCode()
      */
     @Override
@@ -815,7 +821,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
 
     /**
      * Creates a new value group for the given field and values.
-     * 
+     *
      * @param field
      *          the field name
      * @param values
@@ -829,7 +835,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
     /**
      * Returns the filter that will make sure only documents are returned that
      * match all of the values at once.
-     * 
+     *
      * @return the filter builder
      */
     List<FilterBuilder> getFilterBuilders() {
@@ -842,7 +848,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override
@@ -855,7 +861,7 @@ public class ElasticSearchSearchQuery implements QueryBuilder {
 
     /**
      * {@inheritDoc}
-     * 
+     *
      * @see java.lang.Object#hashCode()
      */
     @Override

--- a/modules/weblounge-contentrepository/src/main/resources/elasticsearch/file-mapping.json
+++ b/modules/weblounge-contentrepository/src/main/resources/elasticsearch/file-mapping.json
@@ -14,6 +14,7 @@
 
             "subjects": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
             "template": { "type" : "string", "index" : "not_analyzed", "store" : "yes" }, 
+            "flavor": { "type" : "string", "index" : "not_analyzed", "store" : "yes" }, 
             "stationary": { "type" : "boolean", "index" : "not_analyzed", "store" : "yes" }, 
             "series": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
 

--- a/modules/weblounge-contentrepository/src/main/resources/elasticsearch/image-mapping.json
+++ b/modules/weblounge-contentrepository/src/main/resources/elasticsearch/image-mapping.json
@@ -14,6 +14,7 @@
 
             "subjects": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
             "template": { "type" : "string", "index" : "not_analyzed", "store" : "yes" }, 
+            "flavor": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
             "stationary": { "type" : "boolean", "index" : "not_analyzed", "store" : "yes" }, 
             "series": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
 

--- a/modules/weblounge-contentrepository/src/main/resources/elasticsearch/movie-mapping.json
+++ b/modules/weblounge-contentrepository/src/main/resources/elasticsearch/movie-mapping.json
@@ -14,6 +14,7 @@
 
             "subjects": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
             "template": { "type" : "string", "index" : "not_analyzed", "store" : "yes" }, 
+            "flavor": { "type" : "string", "index" : "not_analyzed", "store" : "yes" }, 
             "stationary": { "type" : "boolean", "index" : "not_analyzed", "store" : "yes" }, 
             "series": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
 

--- a/modules/weblounge-contentrepository/src/main/resources/elasticsearch/page-mapping.json
+++ b/modules/weblounge-contentrepository/src/main/resources/elasticsearch/page-mapping.json
@@ -13,7 +13,8 @@
             "alternate_version": { "type" : "long", "index" : "not_analyzed", "store" : "yes" },
 
             "subjects": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
-            "template": { "type" : "string", "index" : "not_analyzed", "store" : "yes" }, 
+            "template": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
+            "flavor": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
             "stationary": { "type" : "boolean", "index" : "not_analyzed", "store" : "yes" }, 
             "series": { "type" : "string", "index" : "not_analyzed", "store" : "yes" },
 

--- a/modules/weblounge-contentrepository/src/test/resources/file.xml
+++ b/modules/weblounge-contentrepository/src/test/resources/file.xml
@@ -10,7 +10,7 @@
       <description language="fr"><![CDATA[Déscription]]></description>
       <subject><![CDATA[Another photo event]]></subject>
       <subject><![CDATA[Yet another topic]]></subject>
-      <type><![CDATA[Text]]></type>
+      <flavor><![CDATA[Text]]></flavor>
       <coverage language="de"><![CDATA[Zürich]]></coverage>
       <coverage language="fr"><![CDATA[Zurich]]></coverage>
       <rights language="de"><![CDATA[Copyright 2009 by T. Wunden]]></rights>

--- a/modules/weblounge-contentrepository/src/test/resources/image.xml
+++ b/modules/weblounge-contentrepository/src/test/resources/image.xml
@@ -10,7 +10,7 @@
       <description language="fr"><![CDATA[Déscription]]></description>
       <subject><![CDATA[Photo event]]></subject>
       <subject><![CDATA[Another subject]]></subject>
-      <type><![CDATA[File]]></type>
+      <flavor><![CDATA[File]]></flavor>
       <coverage language="de"><![CDATA[Zürich]]></coverage>
       <coverage language="fr"><![CDATA[Zurich]]></coverage>
       <rights language="de"><![CDATA[Copyright 2009 by T. Wunden]]></rights>

--- a/modules/weblounge-contentrepository/src/test/resources/page1.xml
+++ b/modules/weblounge-contentrepository/src/test/resources/page1.xml
@@ -12,7 +12,7 @@
       <description language="fr"><![CDATA[Déscription]]></description>
       <subject><![CDATA[Other topic]]></subject>
       <subject><![CDATA[This subject]]></subject>
-      <type><![CDATA[Text]]></type>
+      <flavor><![CDATA[Text]]></flavor>
       <coverage language="de"><![CDATA[Zürich]]></coverage>
       <coverage language="fr"><![CDATA[Zurich]]></coverage>
       <rights language="de"><![CDATA[Copyright 2009 by T. Wunden]]></rights>

--- a/modules/weblounge-contentrepository/src/test/resources/page2.xml
+++ b/modules/weblounge-contentrepository/src/test/resources/page2.xml
@@ -12,7 +12,7 @@
       <description language="fr"><![CDATA[Déscription]]></description>
       <subject><![CDATA[Topic a]]></subject>
       <subject><![CDATA[This subject]]></subject>
-      <type><![CDATA[Text]]></type>
+      <flavor><![CDATA[Text]]></flavor>
       <coverage language="de"><![CDATA[Zürich]]></coverage>
       <coverage language="fr"><![CDATA[Zurich]]></coverage>
       <rights language="de"><![CDATA[Copyright 2009 by T. Wunden]]></rights>


### PR DESCRIPTION
Rename the existing resource field 'type' to 'flavor' to differentiate between
the the resource type like Page, Image, Movie or File and the flavor of such a
resource like 'News', 'Episode' or 'Series'

This change breaks backward compatibility, since the XML structure of a serial-
ized resource has changed! Only use this with a clean repository/index.
