### PR TITLE
[Bugfix] Fix serialization of publishing context

### DIFF
--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/PublishingContext.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/PublishingContext.java
@@ -355,7 +355,7 @@ public class PublishingContext implements Cloneable {
    * @see #fromXml(Node, XPath)
    */
   public String toXml() {
-    if (publisher == null || startDate == null)
+    if (startDate == null)
       return "";
 
     StringBuffer b = new StringBuffer();


### PR DESCRIPTION
Make sure that the publishing context is serialized if there is no publishing
user set (which is a valid state).
