### PR TITLE
[Improvement] Return 404 Not Found if no preview generator supports the current request

### DIFF
--- a/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/PreviewGenerator.java
+++ b/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/content/PreviewGenerator.java
@@ -39,9 +39,11 @@ public interface PreviewGenerator {
    * 
    * @param resource
    *          the resource
+   * @param language
+   *          the language
    * @return <code>true</code> if creating a preview is supported
    */
-  boolean supports(Resource<?> resource);
+  boolean supports(Resource<?> resource, Language language);
 
   /**
    * Returns <code>true</code> if the preview generator supports creating a

--- a/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/repository/ResourceSerializer.java
+++ b/modules/weblounge-common-api/src/main/java/ch/entwine/weblounge/common/repository/ResourceSerializer.java
@@ -171,9 +171,11 @@ public interface ResourceSerializer<S extends ResourceContent, T extends Resourc
    * 
    * @param resource
    *          the resource
+   * @param language
+   *          the language
    * @return the preview generator
    */
-  PreviewGenerator getPreviewGenerator(Resource<?> resource);
+  PreviewGenerator getPreviewGenerator(Resource<?> resource, Language language);
 
   /**
    * Returns a renderer that can be used to display the resource, e. g as part

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/FileResourceSerializer.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/FileResourceSerializer.java
@@ -86,20 +86,12 @@ public class FileResourceSerializer extends AbstractResourceSerializer<FileConte
     super(FileResource.TYPE);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getMimeType(ch.entwine.weblounge.common.content.ResourceContent)
-   */
+  @Override
   public String getMimeType(FileContent resourceContent) {
     return resourceContent.getMimetype();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#supports(java.lang.String)
-   */
+  @Override
   public boolean supports(String mimeType) {
     // This implementation always returns <code>false</code>, as it is the
     // default implementation anyway. Returning false here will give more
@@ -107,22 +99,12 @@ public class FileResourceSerializer extends AbstractResourceSerializer<FileConte
     return false;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#newResource(ch.entwine.weblounge.common.site.Site)
-   */
+  @Override
   public Resource<FileContent> newResource(Site site) {
     return new FileResourceImpl(new FileResourceURIImpl(site));
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#newResource(ch.entwine.weblounge.common.site.Site,
-   *      java.io.InputStream, ch.entwine.weblounge.common.security.User,
-   *      ch.entwine.weblounge.common.language.Language)
-   */
+  @Override
   public Resource<FileContent> newResource(Site site, InputStream is,
       User user, Language language) {
     Resource<FileContent> fileResource = newResource(site);
@@ -130,34 +112,20 @@ public class FileResourceSerializer extends AbstractResourceSerializer<FileConte
     return fileResource;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.contentrepository.impl.AbstractResourceSerializer#createNewReader()
-   */
   @Override
   protected FileResourceReader createNewReader()
       throws ParserConfigurationException, SAXException {
     return new FileResourceReader();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toMetadata(ch.entwine.weblounge.common.content.Resource)
-   */
+  @Override
   public List<ResourceMetadata<?>> toMetadata(Resource<?> resource) {
     if (resource != null)
       return new FileInputDocument((FileResource) resource).getMetadata();
     return null;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toResource(ch.entwine.weblounge.common.site.Site,
-   *      java.util.List)
-   */
+  @Override
   public Resource<?> toResource(Site site, List<ResourceMetadata<?>> metadata) {
     for (ResourceMetadata<?> metadataItem : metadata) {
       if (XML.equals(metadataItem.getName())) {
@@ -181,12 +149,7 @@ public class FileResourceSerializer extends AbstractResourceSerializer<FileConte
     return null;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toSearchResultItem(ch.entwine.weblounge.common.site.Site,
-   *      double, List)
-   */
+  @Override
   public SearchResultItem toSearchResultItem(Site site, double relevance,
       List<ResourceMetadata<?>> metadata) {
 
@@ -233,24 +196,16 @@ public class FileResourceSerializer extends AbstractResourceSerializer<FileConte
     return result;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getContentReader()
-   */
+  @Override
   public ResourceContentReader<FileContent> getContentReader()
       throws ParserConfigurationException, SAXException {
     return new FileContentReader();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getPreviewGenerator(Resource)
-   */
-  public PreviewGenerator getPreviewGenerator(Resource<?> resource) {
+  @Override
+  public PreviewGenerator getPreviewGenerator(Resource<?> resource, Language language) {
     for (FilePreviewGenerator generator : previewGenerators) {
-      if (generator.supports(resource)) {
+      if (generator.supports(resource, language)) {
         logger.trace("File preview generator {} agrees to handle {}", generator, resource);
         return generator;
       }
@@ -285,11 +240,6 @@ public class FileResourceSerializer extends AbstractResourceSerializer<FileConte
     previewGenerators.remove(generator);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see java.lang.Object#toString()
-   */
   @Override
   public String toString() {
     return "File serializer";

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/ImageResourceSerializer.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/ImageResourceSerializer.java
@@ -97,40 +97,22 @@ public class ImageResourceSerializer extends AbstractResourceSerializer<ImageCon
     super(ImageResource.TYPE);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getMimeType(ch.entwine.weblounge.common.content.ResourceContent)
-   */
+  @Override
   public String getMimeType(ImageContent resourceContent) {
     return resourceContent.getMimetype();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#supports(java.lang.String)
-   */
+  @Override
   public boolean supports(String mimeType) {
     return mimeType != null && mimeType.toLowerCase().startsWith("image/");
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#newResource(ch.entwine.weblounge.common.site.Site)
-   */
+  @Override
   public Resource<ImageContent> newResource(Site site) {
     return new ImageResourceImpl(new ImageResourceURIImpl(site));
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#newResource(ch.entwine.weblounge.common.site.Site,
-   *      java.io.InputStream, ch.entwine.weblounge.common.security.User,
-   *      ch.entwine.weblounge.common.language.Language)
-   */
+  @Override
   public Resource<ImageContent> newResource(Site site, InputStream is,
       User user, Language language) {
     ImageMetadata imageMetadata = ImageMetadataUtils.extractMetadata(new BufferedInputStream(is));
@@ -155,22 +137,13 @@ public class ImageResourceSerializer extends AbstractResourceSerializer<ImageCon
     return imageResource;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.contentrepository.impl.AbstractResourceSerializer#createNewReader()
-   */
   @Override
   protected ImageResourceReader createNewReader()
       throws ParserConfigurationException, SAXException {
     return new ImageResourceReader();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toMetadata(ch.entwine.weblounge.common.content.Resource)
-   */
+  @Override
   public List<ResourceMetadata<?>> toMetadata(Resource<?> resource) {
     if (resource != null) {
       return new ImageInputDocument((ImageResource) resource).getMetadata();
@@ -178,12 +151,7 @@ public class ImageResourceSerializer extends AbstractResourceSerializer<ImageCon
     return null;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toResource(ch.entwine.weblounge.common.site.Site,
-   *      java.util.List)
-   */
+  @Override
   public Resource<?> toResource(Site site, List<ResourceMetadata<?>> metadata) {
     for (ResourceMetadata<?> metadataItem : metadata) {
       if (XML.equals(metadataItem.getName())) {
@@ -207,12 +175,7 @@ public class ImageResourceSerializer extends AbstractResourceSerializer<ImageCon
     return null;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toSearchResultItem(ch.entwine.weblounge.common.site.Site,
-   *      double, List)
-   */
+  @Override
   public SearchResultItem toSearchResultItem(Site site, double relevance,
       List<ResourceMetadata<?>> metadata) {
 
@@ -260,24 +223,16 @@ public class ImageResourceSerializer extends AbstractResourceSerializer<ImageCon
     return result;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getContentReader()
-   */
+  @Override
   public ResourceContentReader<ImageContent> getContentReader()
       throws ParserConfigurationException, SAXException {
     return new ImageContentReader();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getPreviewGenerator(Resource)
-   */
-  public PreviewGenerator getPreviewGenerator(Resource<?> resource) {
+  @Override
+  public PreviewGenerator getPreviewGenerator(Resource<?> resource, Language language) {
     for (ImagePreviewGenerator generator : previewGenerators) {
-      if (generator.supports(resource)) {
+      if (generator.supports(resource, language)) {
         logger.trace("Image preview generator {} agrees to handle {}", generator, resource);
         return generator;
       }

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/MovieResourceSerializer.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/MovieResourceSerializer.java
@@ -86,20 +86,12 @@ public class MovieResourceSerializer extends AbstractResourceSerializer<MovieCon
     super(MovieResource.TYPE);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getMimeType(ch.entwine.weblounge.common.content.ResourceContent)
-   */
+  @Override
   public String getMimeType(MovieContent resourceContent) {
     return resourceContent.getMimetype();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#supports(java.lang.String)
-   */
+  @Override
   public boolean supports(String mimeType) {
     if (mimeType == null)
       return false;
@@ -110,22 +102,12 @@ public class MovieResourceSerializer extends AbstractResourceSerializer<MovieCon
     return false;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#newResource(ch.entwine.weblounge.common.site.Site)
-   */
+  @Override
   public Resource<MovieContent> newResource(Site site) {
     return new MovieResourceImpl(new MovieResourceURIImpl(site));
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#newResource(ch.entwine.weblounge.common.site.Site,
-   *      java.io.InputStream, ch.entwine.weblounge.common.security.User,
-   *      ch.entwine.weblounge.common.language.Language)
-   */
+  @Override
   public Resource<MovieContent> newResource(Site site, InputStream is,
       User user, Language language) {
 
@@ -137,22 +119,13 @@ public class MovieResourceSerializer extends AbstractResourceSerializer<MovieCon
     return avResource;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.contentrepository.impl.AbstractResourceSerializer#createNewReader()
-   */
   @Override
   protected MovieResourceReader createNewReader()
       throws ParserConfigurationException, SAXException {
     return new MovieResourceReader();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toMetadata(ch.entwine.weblounge.common.content.Resource)
-   */
+  @Override
   public List<ResourceMetadata<?>> toMetadata(Resource<?> resource) {
     if (resource != null) {
       return new MovieInputDocument((MovieResource) resource).getMetadata();
@@ -160,12 +133,7 @@ public class MovieResourceSerializer extends AbstractResourceSerializer<MovieCon
     return null;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toResource(ch.entwine.weblounge.common.site.Site,
-   *      java.util.List)
-   */
+  @Override
   public Resource<?> toResource(Site site, List<ResourceMetadata<?>> metadata) {
     for (ResourceMetadata<?> metadataItem : metadata) {
       if (XML.equals(metadataItem.getName())) {
@@ -189,12 +157,7 @@ public class MovieResourceSerializer extends AbstractResourceSerializer<MovieCon
     return null;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toSearchResultItem(ch.entwine.weblounge.common.site.Site,
-   *      double, List)
-   */
+  @Override
   public SearchResultItem toSearchResultItem(Site site, double relevance,
       List<ResourceMetadata<?>> metadata) {
 
@@ -241,24 +204,16 @@ public class MovieResourceSerializer extends AbstractResourceSerializer<MovieCon
     return result;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getContentReader()
-   */
+  @Override
   public ResourceContentReader<MovieContent> getContentReader()
       throws ParserConfigurationException, SAXException {
     return new MovieContentReader();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getPreviewGenerator(Resource)
-   */
-  public PreviewGenerator getPreviewGenerator(Resource<?> resource) {
+  @Override
+  public PreviewGenerator getPreviewGenerator(Resource<?> resource, Language language) {
     for (MoviePreviewGenerator generator : previewGenerators) {
-      if (generator.supports(resource)) {
+      if (generator.supports(resource, language)) {
         logger.trace("Movie preview generator {} agrees to handle {}", generator, resource);
         return generator;
       }

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/PageSerializer.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/PageSerializer.java
@@ -82,71 +82,39 @@ public class PageSerializer extends AbstractResourceSerializer<ResourceContent, 
     super(Page.TYPE);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getMimeType(ch.entwine.weblounge.common.content.ResourceContent)
-   */
+  @Override
   public String getMimeType(ResourceContent resourceContent) {
     return "text/html";
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#supports(java.lang.String)
-   */
+  @Override
   public boolean supports(String mimeType) {
     return false;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#newResource(ch.entwine.weblounge.common.site.Site)
-   */
+  @Override
   public Resource<ResourceContent> newResource(Site site) {
     return new PageImpl(new PageURIImpl(site));
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#newResource(ch.entwine.weblounge.common.site.Site,
-   *      java.io.InputStream, ch.entwine.weblounge.common.security.User,
-   *      ch.entwine.weblounge.common.language.Language)
-   */
+  @Override
   public Resource<ResourceContent> newResource(Site site, InputStream is,
       User user, Language language) {
     return newResource(site);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.contentrepository.impl.AbstractResourceSerializer#createNewReader()
-   */
   @Override
   protected PageReader createNewReader() throws ParserConfigurationException,
       SAXException {
     return new PageReader();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toMetadata(ch.entwine.weblounge.common.content.Resource)
-   */
+  @Override
   public List<ResourceMetadata<?>> toMetadata(Resource<?> resource) {
     return new PageInputDocument((Page) resource).getMetadata();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toResource(ch.entwine.weblounge.common.site.Site,
-   *      java.util.List)
-   */
+  @Override
   public Resource<?> toResource(Site site, List<ResourceMetadata<?>> metadata) {
     for (ResourceMetadata<?> metadataItem : metadata) {
       if (XML.equals(metadataItem.getName())) {
@@ -170,12 +138,7 @@ public class PageSerializer extends AbstractResourceSerializer<ResourceContent, 
     return null;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#toSearchResultItem(ch.entwine.weblounge.common.site.Site,
-   *      double, List)
-   */
+  @Override
   public SearchResultItem toSearchResultItem(Site site, double relevance,
       List<ResourceMetadata<?>> metadata) {
 
@@ -209,24 +172,16 @@ public class PageSerializer extends AbstractResourceSerializer<ResourceContent, 
     return result;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getContentReader()
-   */
+  @Override
   public ResourceContentReader<ResourceContent> getContentReader()
       throws ParserConfigurationException, SAXException {
     return null;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.repository.ResourceSerializer#getPreviewGenerator(Resource)
-   */
-  public PreviewGenerator getPreviewGenerator(Resource<?> resource) {
+  @Override
+  public PreviewGenerator getPreviewGenerator(Resource<?> resource, Language language) {
     for (PagePreviewGenerator generator : previewGenerators) {
-      if (generator.supports(resource)) {
+      if (generator.supports(resource, language)) {
         logger.trace("Page preview generator {} agrees to handle {}", generator, resource);
         return generator;
       }

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/PreviewGeneratorWorker.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/PreviewGeneratorWorker.java
@@ -112,28 +112,16 @@ class PreviewGeneratorWorker implements Runnable {
     this.canceled = true;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see java.lang.Runnable#run()
-   */
+  @Override
   public void run() {
     ResourceURI resourceURI = resource.getURI();
     String resourceType = resourceURI.getType();
 
     try {
-
       // Find the resource serializer
       ResourceSerializer<?, ?> serializer = contentRepository.getSerializerByType(resourceType);
       if (serializer == null) {
         logger.warn("Unable to index resources of type '{}': no resource serializer found", resourceType);
-        return;
-      }
-
-      // Does the serializer come with a preview generator?
-      PreviewGenerator previewGenerator = serializer.getPreviewGenerator(resource);
-      if (previewGenerator == null) {
-        logger.debug("Resource type '{}' does not support previews", resourceType);
         return;
       }
 
@@ -158,6 +146,14 @@ class PreviewGeneratorWorker implements Runnable {
 
       // Now scale the original preview according to the existing styles
       for (Language l : languages) {
+        
+        // Does the serializer come with a preview generator?
+        PreviewGenerator previewGenerator = serializer.getPreviewGenerator(resource, l);
+        if (previewGenerator == null) {
+          logger.debug("No preview generator found for resource '{}' with language '{}'", resource, l);
+          continue;
+        }
+        
         if (!resource.supportsContentLanguage(l))
           continue;
 

--- a/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/endpoint/PreviewsEndpoint.java
+++ b/modules/weblounge-contentrepository/src/main/java/ch/entwine/weblounge/contentrepository/impl/endpoint/PreviewsEndpoint.java
@@ -207,7 +207,7 @@ public class PreviewsEndpoint extends ContentRepositoryEndpoint {
       throw new WebApplicationException(Status.PRECONDITION_FAILED);
 
     // Does the serializer come with a preview generator?
-    PreviewGenerator previewGenerator = serializer.getPreviewGenerator(resource);
+    PreviewGenerator previewGenerator = serializer.getPreviewGenerator(resource, language);
     if (previewGenerator == null)
       throw new WebApplicationException(Status.NOT_FOUND);
 
@@ -559,7 +559,7 @@ public class PreviewsEndpoint extends ContentRepositoryEndpoint {
       throw new WebApplicationException(Status.PRECONDITION_FAILED);
 
     // Does the serializer come with a preview generator?
-    PreviewGenerator previewGenerator = serializer.getPreviewGenerator(resource);
+    PreviewGenerator previewGenerator = serializer.getPreviewGenerator(resource, language);
     if (previewGenerator == null)
       throw new WebApplicationException(Status.NOT_FOUND);
 

--- a/modules/weblounge-dispatcher/src/main/java/ch/entwine/weblounge/dispatcher/impl/handler/PreviewRequestHandlerImpl.java
+++ b/modules/weblounge-dispatcher/src/main/java/ch/entwine/weblounge/dispatcher/impl/handler/PreviewRequestHandlerImpl.java
@@ -247,7 +247,7 @@ public final class PreviewRequestHandlerImpl implements RequestHandler {
     PreviewGenerator previewGenerator = null;
     synchronized (previewGenerators) {
       for (PreviewGenerator generator : previewGenerators) {
-        if (generator.supports(resource)) {
+        if (generator.supports(resource, language)) {
           previewGenerator = generator;
           break;
         }
@@ -257,7 +257,7 @@ public final class PreviewRequestHandlerImpl implements RequestHandler {
     // If we did not find a preview generator, we need to let go
     if (previewGenerator == null) {
       logger.debug("Unable to generate preview for {} since no suitable preview generator is available", resource);
-      DispatchUtils.sendServiceUnavailable(request, response);
+      DispatchUtils.sendNotFound(request, response);
       return true;
     }
 

--- a/modules/weblounge-preview/src/main/java/ch/entwine/weblounge/preview/imagemagick/ImageMagickPreviewGenerator.java
+++ b/modules/weblounge-preview/src/main/java/ch/entwine/weblounge/preview/imagemagick/ImageMagickPreviewGenerator.java
@@ -92,20 +92,12 @@ public final class ImageMagickPreviewGenerator implements ImagePreviewGenerator 
     FileUtils.deleteQuietly(imageMagickDir);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#supports(ch.entwine.weblounge.common.content.Resource)
-   */
-  public boolean supports(Resource<?> resource) {
+  @Override
+  public boolean supports(Resource<?> resource, Language language) {
     return (resource instanceof ImageResource);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#supports(java.lang.String)
-   */
+  @Override
   public boolean supports(String format) {
     if (format == null)
       throw new IllegalArgumentException("Format cannot be null");
@@ -145,15 +137,7 @@ public final class ImageMagickPreviewGenerator implements ImagePreviewGenerator 
     }
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#createPreview(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.site.Environment,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle, String,
-   *      java.io.InputStream, java.io.OutputStream)
-   */
+  @Override
   public void createPreview(Resource<?> resource, Environment environment,
       Language language, ImageStyle style, String format, InputStream is,
       OutputStream os) throws IOException {
@@ -172,15 +156,7 @@ public final class ImageMagickPreviewGenerator implements ImagePreviewGenerator 
     style(is, os, format, style);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.image.ImagePreviewGenerator#createPreview(java.io.File,
-   *      ch.entwine.weblounge.common.site.Environment,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle,
-   *      java.lang.String, java.io.InputStream, java.io.OutputStream)
-   */
+  @Override
   public void createPreview(File imageFile, Environment environment,
       Language language, ImageStyle style, String format, InputStream is,
       OutputStream os) throws IOException {
@@ -195,26 +171,14 @@ public final class ImageMagickPreviewGenerator implements ImagePreviewGenerator 
     style(is, os, format, style);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getContentType(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle)
-   */
+  @Override
   public String getContentType(Resource<?> resource, Language language,
       ImageStyle style) {
     String mimetype = resource.getContent(language).getMimetype();
     return mimetype;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getSuffix(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle)
-   */
+  @Override
   public String getSuffix(Resource<?> resource, Language language,
       ImageStyle style) {
     // Load the resource
@@ -242,11 +206,7 @@ public final class ImageMagickPreviewGenerator implements ImagePreviewGenerator 
     return FilenameUtils.getExtension(filename);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getPriority()
-   */
+  @Override
   public int getPriority() {
     return 100;
   }

--- a/modules/weblounge-preview/src/main/java/ch/entwine/weblounge/preview/jai/JAIPreviewGenerator.java
+++ b/modules/weblounge-preview/src/main/java/ch/entwine/weblounge/preview/jai/JAIPreviewGenerator.java
@@ -60,35 +60,19 @@ public final class JAIPreviewGenerator implements ImagePreviewGenerator {
   /** The logging facility */
   private static final Logger logger = LoggerFactory.getLogger(JAIPreviewGenerator.class);
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#supports(ch.entwine.weblounge.common.content.Resource)
-   */
-  public boolean supports(Resource<?> resource) {
+  @Override
+  public boolean supports(Resource<?> resource, Language language) {
     return (resource instanceof ImageResource);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#supports(java.lang.String)
-   */
+  @Override
   public boolean supports(String format) {
     if (format == null)
       throw new IllegalArgumentException("Format cannot be null");
     return ImageIO.getImageWritersBySuffix(format.toLowerCase()).hasNext();
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#createPreview(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.site.Environment,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle, String,
-   *      java.io.InputStream, java.io.OutputStream)
-   */
+  @Override
   public void createPreview(Resource<?> resource, Environment environment,
       Language language, ImageStyle style, String format, InputStream is,
       OutputStream os) throws IOException {
@@ -106,15 +90,7 @@ public final class JAIPreviewGenerator implements ImagePreviewGenerator {
     style(is, os, format, style);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.image.ImagePreviewGenerator#createPreview(java.io.File,
-   *      ch.entwine.weblounge.common.site.Environment,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle,
-   *      java.lang.String, java.io.InputStream, java.io.OutputStream)
-   */
+  @Override
   public void createPreview(File imageFile, Environment environment,
       Language language, ImageStyle style, String format, InputStream is,
       OutputStream os) throws IOException {
@@ -129,26 +105,14 @@ public final class JAIPreviewGenerator implements ImagePreviewGenerator {
     style(is, os, format, style);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getContentType(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle)
-   */
+  @Override
   public String getContentType(Resource<?> resource, Language language,
       ImageStyle style) {
     String mimetype = resource.getContent(language).getMimetype();
     return mimetype;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getSuffix(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle)
-   */
+  @Override
   public String getSuffix(Resource<?> resource, Language language,
       ImageStyle style) {
 
@@ -177,11 +141,7 @@ public final class JAIPreviewGenerator implements ImagePreviewGenerator {
     return FilenameUtils.getExtension(filename);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getPriority()
-   */
+  @Override
   public int getPriority() {
     return 0;
   }

--- a/modules/weblounge-preview/src/main/java/ch/entwine/weblounge/preview/phantomjs/PhantomJsPagePreviewGenerator.java
+++ b/modules/weblounge-preview/src/main/java/ch/entwine/weblounge/preview/phantomjs/PhantomJsPagePreviewGenerator.java
@@ -123,20 +123,12 @@ public class PhantomJsPagePreviewGenerator implements PagePreviewGenerator {
     FileUtils.deleteQuietly(phantomTmpDir);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#supports(ch.entwine.weblounge.common.content.Resource)
-   */
-  public boolean supports(Resource<?> resource) {
+  @Override
+  public boolean supports(Resource<?> resource, Language language) {
     return (resource instanceof Page);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#supports(java.lang.String)
-   */
+  @Override
   public boolean supports(String format) {
     for (ImagePreviewGenerator generator : previewGenerators) {
       if (generator.supports(PREVIEW_FORMAT) && generator.supports(format))
@@ -145,15 +137,7 @@ public class PhantomJsPagePreviewGenerator implements PagePreviewGenerator {
     return false;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#createPreview(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.site.Environment,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle, String,
-   *      java.io.InputStream, java.io.OutputStream)
-   */
+  @Override
   public void createPreview(Resource<?> resource, Environment environment,
       Language language, ImageStyle style, String format, InputStream is,
       OutputStream os) throws IOException {
@@ -255,35 +239,19 @@ public class PhantomJsPagePreviewGenerator implements PagePreviewGenerator {
 
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getContentType(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle)
-   */
+  @Override
   public String getContentType(Resource<?> resource, Language language,
       ImageStyle style) {
     return PREVIEW_CONTENT_TYPE;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getSuffix(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle)
-   */
+  @Override
   public String getSuffix(Resource<?> resource, Language language,
       ImageStyle style) {
     return PREVIEW_FORMAT;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getPriority()
-   */
+  @Override
   public int getPriority() {
     return 100;
   }
@@ -381,11 +349,6 @@ public class PhantomJsPagePreviewGenerator implements PagePreviewGenerator {
       super(ctx, ImagePreviewGenerator.class.getName(), null);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.osgi.util.tracker.ServiceTracker#addingService(org.osgi.framework.ServiceReference)
-     */
     @Override
     public Object addingService(ServiceReference reference) {
       ImagePreviewGenerator previewGenerator = (ImagePreviewGenerator) super.addingService(reference);
@@ -393,12 +356,6 @@ public class PhantomJsPagePreviewGenerator implements PagePreviewGenerator {
       return previewGenerator;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.osgi.util.tracker.ServiceTracker#removedService(org.osgi.framework.ServiceReference,
-     *      java.lang.Object)
-     */
     @Override
     public void removedService(ServiceReference reference, Object service) {
       removePreviewGenerator((ImagePreviewGenerator) service);

--- a/modules/weblounge-preview/src/main/java/ch/entwine/weblounge/preview/xhtmlrenderer/XhtmlRendererPagePreviewGenerator.java
+++ b/modules/weblounge-preview/src/main/java/ch/entwine/weblounge/preview/xhtmlrenderer/XhtmlRendererPagePreviewGenerator.java
@@ -162,20 +162,12 @@ public class XhtmlRendererPagePreviewGenerator implements PagePreviewGenerator {
     }
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#supports(ch.entwine.weblounge.common.content.Resource)
-   */
-  public boolean supports(Resource<?> resource) {
+  @Override
+  public boolean supports(Resource<?> resource, Language language) {
     return (resource instanceof Page);
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#supports(java.lang.String)
-   */
+  @Override
   public boolean supports(String format) {
     for (ImagePreviewGenerator generator : previewGenerators) {
       if (generator.supports(PREVIEW_FORMAT) && generator.supports(format))
@@ -184,24 +176,12 @@ public class XhtmlRendererPagePreviewGenerator implements PagePreviewGenerator {
     return false;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getPriority()
-   */
+  @Override
   public int getPriority() {
     return 0;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#createPreview(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.site.Environment,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle, String,
-   *      java.io.InputStream, java.io.OutputStream)
-   */
+  @Override
   public void createPreview(Resource<?> resource, Environment environment,
       Language language, ImageStyle style, String format, InputStream is,
       OutputStream os) throws IOException {
@@ -417,25 +397,13 @@ public class XhtmlRendererPagePreviewGenerator implements PagePreviewGenerator {
     }
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getContentType(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle)
-   */
+  @Override
   public String getContentType(Resource<?> resource, Language language,
       ImageStyle style) {
     return PREVIEW_CONTENT_TYPE;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.PreviewGenerator#getSuffix(ch.entwine.weblounge.common.content.Resource,
-   *      ch.entwine.weblounge.common.language.Language,
-   *      ch.entwine.weblounge.common.content.image.ImageStyle)
-   */
+  @Override
   public String getSuffix(Resource<?> resource, Language language,
       ImageStyle style) {
     return PREVIEW_FORMAT;
@@ -515,11 +483,6 @@ public class XhtmlRendererPagePreviewGenerator implements PagePreviewGenerator {
       super(ctx, filter, null);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.osgi.util.tracker.ServiceTracker#addingService(org.osgi.framework.ServiceReference)
-     */
     @Override
     public Object addingService(ServiceReference reference) {
       Servlet servlet = (Servlet) super.addingService(reference);
@@ -528,12 +491,6 @@ public class XhtmlRendererPagePreviewGenerator implements PagePreviewGenerator {
       return servlet;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.osgi.util.tracker.ServiceTracker#removedService(org.osgi.framework.ServiceReference,
-     *      java.lang.Object)
-     */
     @Override
     public void removedService(ServiceReference reference, Object service) {
       String site = (String) reference.getProperty("site");
@@ -560,11 +517,6 @@ public class XhtmlRendererPagePreviewGenerator implements PagePreviewGenerator {
       super(ctx, ImagePreviewGenerator.class.getName(), null);
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.osgi.util.tracker.ServiceTracker#addingService(org.osgi.framework.ServiceReference)
-     */
     @Override
     public Object addingService(ServiceReference reference) {
       ImagePreviewGenerator previewGenerator = (ImagePreviewGenerator) super.addingService(reference);
@@ -572,12 +524,6 @@ public class XhtmlRendererPagePreviewGenerator implements PagePreviewGenerator {
       return previewGenerator;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.osgi.util.tracker.ServiceTracker#removedService(org.osgi.framework.ServiceReference,
-     *      java.lang.Object)
-     */
     @Override
     public void removedService(ServiceReference reference, Object service) {
       removePreviewGenerator((ImagePreviewGenerator) service);
@@ -605,21 +551,11 @@ public class XhtmlRendererPagePreviewGenerator implements PagePreviewGenerator {
       this.baseURL = baseURL.toExternalForm();
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.xhtmlrenderer.swing.NaiveUserAgent#getBaseURL()
-     */
     @Override
     public String getBaseURL() {
       return baseURL;
     }
 
-    /**
-     * {@inheritDoc}
-     * 
-     * @see org.xhtmlrenderer.swing.NaiveUserAgent#resolveURI(java.lang.String)
-     */
     @Override
     public String resolveURI(String uri) {
       if (uri == null)


### PR DESCRIPTION
If no available preview generator supports to generate a preview for a resource/
language it's very unlikely that the next time the preview is requested it can
be created and served successfully. Therefore send a 404 Not Found instead of
503 Service Unavailable.
