### PR TITLE
[Improvement] Make instance information available as a service

### DIFF
--- a/modules/weblounge-dispatcher/src/main/java/ch/entwine/weblounge/dispatcher/impl/DispatcherServiceImpl.java
+++ b/modules/weblounge-dispatcher/src/main/java/ch/entwine/weblounge/dispatcher/impl/DispatcherServiceImpl.java
@@ -25,8 +25,8 @@ import ch.entwine.weblounge.dispatcher.DispatcherService;
 import ch.entwine.weblounge.dispatcher.RequestHandler;
 import ch.entwine.weblounge.dispatcher.SharedHttpContext;
 import ch.entwine.weblounge.dispatcher.SiteDispatcherService;
+import ch.entwine.weblounge.kernel.runtime.InstanceInformation;
 
-import org.apache.commons.lang.StringUtils;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.ConfigurationException;
@@ -54,9 +54,6 @@ public class DispatcherServiceImpl implements DispatcherService, ManagedService 
   /** Logging instance */
   private static final Logger logger = LoggerFactory.getLogger(DispatcherServiceImpl.class);
 
-  /** Property name of the weblounge instance */
-  private static final String OPT_INSTANCE_NAME = "ch.entwine.weblounge.name";
-  
   /** The main dispatcher servlet */
   private WebloungeDispatcherServlet dispatcher = null;
 
@@ -66,9 +63,9 @@ public class DispatcherServiceImpl implements DispatcherService, ManagedService 
   /** The environment */
   private Environment environment = Environment.Production;
 
-  /** Name of this Weblounge instance */
-  private String instanceName = null;
-  
+  /** The Weblounge instance information */
+  private InstanceInformation instance = null;
+
   /**
    * Creates a new instance of the dispatcher service.
    */
@@ -105,13 +102,12 @@ public class DispatcherServiceImpl implements DispatcherService, ManagedService 
     initParams.put(SharedHttpContext.PATTERN, ".*");
     dispatcherServiceRegistration = bundleContext.registerService(Servlet.class.getName(), dispatcher, initParams);
 
-    instanceName = StringUtils.trimToNull(context.getBundleContext().getProperty(OPT_INSTANCE_NAME));
-    if (instanceName != null)
-      logger.info("Instance name is '{}'", instanceName);
+    if (instance.getName() != null)
+      logger.info("Instance name is '{}'", instance.getName());
     else
       logger.debug("No explicit instance name has been set");
-    dispatcher.setName(instanceName);
-    
+    dispatcher.setName(instance.getName());
+
     logger.debug("Weblounge dispatcher activated");
   }
 
@@ -160,6 +156,14 @@ public class DispatcherServiceImpl implements DispatcherService, ManagedService 
    */
   void setSiteDispatcher(SiteDispatcherService siteDispatcher) {
     dispatcher.setSiteDispatcher(siteDispatcher);
+  }
+
+  /**
+   * Callback from the OSGi environment when the instance information is
+   * published.
+   */
+  void setInstanceInformation(InstanceInformation instance) {
+    this.instance = instance;
   }
 
   /**

--- a/modules/weblounge-dispatcher/src/main/resources/OSGI-INF/dispatcher-service.xml
+++ b/modules/weblounge-dispatcher/src/main/resources/OSGI-INF/dispatcher-service.xml
@@ -16,5 +16,6 @@
   <reference name="cacheservice" interface="ch.entwine.weblounge.cache.CacheService" cardinality="0..n" policy="dynamic" bind="addCacheService" unbind="removeCacheService" />
   <reference name="httpcontext" interface="org.osgi.service.http.HttpContext" target="(contextId=weblounge)" cardinality="1..1" policy="static" />
   <reference name="environment" interface="ch.entwine.weblounge.common.site.Environment" cardinality="1..1" policy="static" bind="setEnvironment" />
+  <reference name="instanceinformation" interface="ch.entwine.weblounge.kernel.runtime.InstanceInformation" cardinality="1..1" policy="static" bind="setInstanceInformation" />
 
 </scr:component>

--- a/modules/weblounge-kernel/pom.xml
+++ b/modules/weblounge-kernel/pom.xml
@@ -651,6 +651,7 @@
               OSGI-INF/fop-service.xml,
               OSGI-INF/healthcheck-filter.xml,
               OSGI-INF/https-request-filter.xml,
+              OSGI-INF/instance-information-service.xml,
               OSGI-INF/kernel-service.xml,
               OSGI-INF/language-runtime-information.xml,
               OSGI-INF/resource-publishing-service.xml,

--- a/modules/weblounge-kernel/src/main/java/ch/entwine/weblounge/kernel/runtime/InstanceInformation.java
+++ b/modules/weblounge-kernel/src/main/java/ch/entwine/weblounge/kernel/runtime/InstanceInformation.java
@@ -1,0 +1,67 @@
+/*
+ * Weblounge: Web Content Management System Copyright (c) 2014 The Weblounge
+ * Team http://entwinemedia.com/weblounge
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option) any
+ * later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ch.entwine.weblounge.kernel.runtime;
+
+import org.apache.commons.lang.StringUtils;
+import org.osgi.service.component.ComponentContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides information about the current Weblounge instance.
+ */
+public class InstanceInformation {
+
+  /** The name of the current instance */
+  private String name = null;
+
+  /** Property name of the Weblounge instance */
+  private static final String OPT_INSTANCE_NAME = "ch.entwine.weblounge.name";
+
+  /** The logging facility */
+  private static final Logger logger = LoggerFactory.getLogger(InstanceInformation.class);
+
+  /**
+   * OSGi component activation method.
+   * 
+   * @param context
+   *          the component context
+   */
+  void activate(ComponentContext context) {
+    if (context == null)
+      throw new IllegalArgumentException("Component context must not be null");
+
+    name = StringUtils.trimToNull(context.getBundleContext().getProperty(OPT_INSTANCE_NAME));
+    if (name != null)
+      logger.info("Instance name is '{}'", name);
+    else
+      logger.debug("No explicit instance name has been set");
+  }
+
+  /**
+   * Returns the name of the current Weblounge instance or {@code null} if no
+   * explicit instance name has been set.
+   * 
+   * @return the instance name
+   */
+  public String getName() {
+    return name;
+  }
+
+}

--- a/modules/weblounge-kernel/src/main/resources/OSGI-INF/instance-information-service.xml
+++ b/modules/weblounge-kernel/src/main/resources/OSGI-INF/instance-information-service.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0"
+  immediate="true"
+  activate="activate"
+  name="Weblounge Instance Information Service">
+
+  <implementation class="ch.entwine.weblounge.kernel.runtime.InstanceInformation" />
+  <service>
+    <provide interface="ch.entwine.weblounge.kernel.runtime.InstanceInformation" />
+  </service>
+
+</scr:component>

--- a/modules/weblounge-kernel/src/test/java/ch/entwine/weblounge/kernel/runtime/InstanceInformationTest.java
+++ b/modules/weblounge-kernel/src/test/java/ch/entwine/weblounge/kernel/runtime/InstanceInformationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Weblounge: Web Content Management System Copyright (c) 2014 The Weblounge
+ * Team http://entwinemedia.com/weblounge
+ * 
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option) any
+ * later version.
+ * 
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package ch.entwine.weblounge.kernel.runtime;
+
+import static org.junit.Assert.assertEquals;
+
+import static org.easymock.EasyMock.createNiceMock;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.replay;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.ComponentContext;
+
+/**
+ * Tests for class {@link InstanceInformation}
+ */
+public class InstanceInformationTest {
+
+  private static final String OPT_INSTANCE_NAME = "ch.entwine.weblounge.name";
+  
+  private InstanceInformation service;
+  
+  @Before
+  public void setUp() {
+    service = new InstanceInformation();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testActivateWithNullContext() {
+    service.activate(null);
+  }
+  
+  @Test
+  public void testActivate() {
+    BundleContext bundleContext = createNiceMock(BundleContext.class);
+    expect(bundleContext.getProperty(OPT_INSTANCE_NAME)).andStubReturn(null);
+    replay(bundleContext);
+    
+    ComponentContext context = createNiceMock(ComponentContext.class);
+    expect(context.getBundleContext()).andStubReturn(bundleContext);
+    replay(context);
+    
+    service.activate(context);
+    assertNull(service.getName());
+    
+
+    bundleContext = createNiceMock(BundleContext.class);
+    expect(bundleContext.getProperty(OPT_INSTANCE_NAME)).andStubReturn("instance01");
+    replay(bundleContext);
+    
+    context = createNiceMock(ComponentContext.class);
+    expect(context.getBundleContext()).andStubReturn(bundleContext);
+    replay(context);
+    
+    service.activate(context);
+    assertEquals("instance01", service.getName());
+  }
+  
+}


### PR DESCRIPTION
The new service provides access to instance information for any consumer.
Currently the only information available is the name of the instance.
