### PR TITLE
[Improvement] Refactor ImageContentReader to be OpenJDK compatible

### DIFF
--- a/modules/weblounge-common/pom.xml
+++ b/modules/weblounge-common/pom.xml
@@ -141,18 +141,6 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.media.jai</groupId>
-      <artifactId>com.springsource.javax.media.jai.core</artifactId>
-      <version>1.1.3</version>
-    </dependency>
-
-    <dependency>
-      <groupId>javax.media.jai</groupId>
-      <artifactId>com.springsource.javax.media.jai.codec</artifactId>
-      <version>1.1.3</version>
-    </dependency>
-
-    <dependency>
       <groupId>net.sf.jtidy</groupId>
       <artifactId>jtidy</artifactId>
       <version>r938</version>
@@ -279,8 +267,6 @@
             <Embed-Dependency>
               freemarker;inline=true,
               metadata-extractor;inline=true,
-              com.springsource.javax.media.jai.core;inline=true,
-              com.springsource.javax.media.jai.codec;inline=true,
               jtidy;inline=true
             </Embed-Dependency>
             <_exportcontents>

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/ResourceContentReaderImpl.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/ResourceContentReaderImpl.java
@@ -78,11 +78,7 @@ public abstract class ResourceContentReaderImpl<T extends ResourceContent> exten
     parserRef = new WeakReference<SAXParser>(parserFactory.newSAXParser());
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.ResourceContentReader#createFromXml(java.io.InputStream)
-   */
+  @Override
   public T createFromXml(InputStream is) throws SAXException, IOException,
       ParserConfigurationException {
 

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/image/ImageContentReader.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/image/ImageContentReader.java
@@ -72,19 +72,7 @@ public class ImageContentReader extends ResourceContentReaderImpl<ImageContent> 
     parserRef = new WeakReference<SAXParser>(parserFactory.newSAXParser());
   }
 
-  /**
-   * This method is called to parse the serialized XML of a
-   * {@link ch.entwine.weblounge.common.content.ResourceContent}.
-   * 
-   * @param is
-   *          the content data
-   * @throws ParserConfigurationException
-   *           if the SAX parser setup failed
-   * @throws IOException
-   *           if reading the input stream fails
-   * @throws SAXException
-   *           if an error occurs while parsing
-   */
+  @Override
   public ImageContent createFromXml(InputStream is) throws SAXException,
       IOException, ParserConfigurationException {
 
@@ -97,12 +85,7 @@ public class ImageContentReader extends ResourceContentReaderImpl<ImageContent> 
     return content;
   }
 
-  /**
-   * {@inheritDoc}
-   * 
-   * @see ch.entwine.weblounge.common.content.ResourceContentReader#createFromContent(java.io.InputStream,
-   *      ch.entwine.weblounge.common.language.Language, long, java.lang.String)
-   */
+  @Override
   public ImageContent createFromContent(InputStream is, User user,
       Language language, long size, String fileName, String mimeType)
       throws IOException {

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/image/ImageContentReader.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/image/ImageContentReader.java
@@ -102,7 +102,7 @@ public class ImageContentReader extends ResourceContentReaderImpl<ImageContent> 
     try (final ByteArrayInputStream bais = new ByteArrayInputStream(imgData)) {
       readDimensions(content, bais);
     } catch (Throwable t) {
-      logger.warn("Error extracting metadata using java advanced imaging (jai) from {}: {}", fileName, t.getMessage());
+      logger.warn("Error extracting metadata using ImageIO from {}: {}", fileName, t.getMessage());
       throw new IOException(t);
     }
 

--- a/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/image/ImageMetadataUtils.java
+++ b/modules/weblounge-common/src/main/java/ch/entwine/weblounge/common/impl/content/image/ImageMetadataUtils.java
@@ -89,8 +89,6 @@ public final class ImageMetadataUtils {
     try {
       meta = ImageMetadataReader.readMetadata(img);
     } catch (ImageProcessingException e) {
-      if ("File is not the correct format".equals(e.getMessage()))
-        return null;
       logger.warn("Failed to extract image metadata from image: {}", e.getMessage());
       return null;
     }


### PR DESCRIPTION
OpenJDK does not include some Sun specific image manipulation classes (package
com.sun.image.codec.jpeg). Therefore change the way how image dimensions are
read by using ImageIO instead of JAI.
